### PR TITLE
feat: add macOS app build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 dist/
 out/
 build/
+release/
 *.tsbuildinfo
 
 # OS artifacts

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ npm run build
 npx electron .
 ```
 
+### Build as macOS App
+
+Generate a standalone `Clui CC.app` that runs without a terminal:
+
+```bash
+npm run dist
+```
+
+The app is created at `release/mac-arm64/Clui CC.app` (Apple Silicon) or `release/mac/Clui CC.app` (Intel).
+
+To install, drag it to `/Applications`:
+
+```bash
+cp -R "release/mac-arm64/Clui CC.app" /Applications/
+```
+
+Then open it from Spotlight, Launchpad, or the Applications folder like any native app.
+
+> **Note:** The app is not code-signed. On first launch macOS may block it — go to **System Settings → Privacy & Security** and click **Open Anyway**.
+
 </details>
 
 <details>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
+    "dist": "electron-vite build --mode production && electron-builder --mac --dir",
     "doctor": "bash scripts/doctor.sh",
     "postinstall": "electron-builder install-app-deps && bash scripts/patch-dev-icon.sh"
   },
@@ -30,6 +31,15 @@
   "build": {
     "appId": "com.clui.app",
     "productName": "Clui CC",
+    "directories": {
+      "output": "release"
+    },
+    "files": [
+      "dist/main/**/*",
+      "dist/preload/**/*",
+      "dist/renderer/**/*",
+      "package.json"
+    ],
     "mac": {
       "icon": "resources/icon.icns"
     }


### PR DESCRIPTION
## Summary

- Add `files` and `directories` config to `electron-builder` so packaging actually works (without it, the build fails because the entry file isn't found in the asar)
- Add `npm run dist` script to generate a standalone `Clui CC.app`
- Add `release/` to `.gitignore`
- Document the build process in README (Development Commands section)

## Context

Running Clui CC via `./start.command` ties it to an open terminal. With this change, users can run `npm run dist` to generate a native `.app`, drag it to `/Applications`, and launch it like any macOS app — no terminal needed.

## Test plan

- [ ] Run `npm run dist` on a fresh clone
- [ ] Verify `Clui CC.app` is created in `release/mac-arm64/`
- [ ] Copy to `/Applications` and launch — confirm it works without terminal
- [ ] Verify code signing warning appears and "Open Anyway" resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)