### PR TITLE
Fix Whisper brew formula: whisper-cli → whisperkit-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ claude
 **Step 6.** Install Whisper for voice input:
 
 ```bash
-brew install whisper-cli
+brew install whisperkit-cli
 ```
 
 > **No API keys or `.env` file required.** Clui CC uses your existing Claude Code CLI authentication (Pro/Team/Enterprise subscription).

--- a/commands/install-app.command
+++ b/commands/install-app.command
@@ -35,7 +35,7 @@ fi
 
 step "Step 2/6 — Checking voice support (Whisper)"
 
-if command -v whisper-cli &>/dev/null || command -v whisper &>/dev/null; then
+if command -v whisperkit-cli &>/dev/null || command -v whisper &>/dev/null; then
   echo "Whisper is already installed."
 else
   echo "Whisper is not installed. Voice input requires it."
@@ -54,12 +54,12 @@ else
 
   echo "Installing Whisper via Homebrew..."
   echo
-  if ! brew install whisper-cli; then
+  if ! brew install whisperkit-cli; then
     echo
     echo "Whisper installation failed."
     echo
     echo "  Try running manually:"
-    echo "    brew install whisper-cli"
+    echo "    brew install whisperkit-cli"
     echo
     echo "  Then double-click this file again."
     echo
@@ -67,12 +67,12 @@ else
   fi
 
   # Verify
-  if ! command -v whisper-cli &>/dev/null && ! command -v whisper &>/dev/null; then
+  if ! command -v whisperkit-cli &>/dev/null && ! command -v whisper &>/dev/null; then
     echo
     echo "Whisper was installed but the command is not available."
     echo
     echo "  Try opening a new Terminal window and running:"
-    echo "    whisper-cli --help"
+    echo "    whisperkit-cli --help"
     echo
     echo "  If that works, double-click this file again."
     echo

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,7 +155,7 @@ If not, install it:
 2. Install Whisper manually:
 
 ```bash
-brew install whisper-cli
+brew install whisperkit-cli
 ```
 
 3. Rerun the installer:

--- a/docs/oss-readiness-report.md
+++ b/docs/oss-readiness-report.md
@@ -91,7 +91,7 @@
 - Node.js 18+ (for Electron 33)
 - macOS (primary platform — Electron transparent window, tray, node-pty)
 - `claude` CLI installed and authenticated (core dependency)
-- Optional: `whisper-cli` or `whisper` + model for voice transcription
+- Optional: `whisperkit-cli` or `whisper` + model for voice transcription
 
 ### Build System
 - `npm install` → `npm run dev` (hot-reload) or `npm run build` (production)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -656,10 +656,10 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     const buf = Buffer.from(audioBase64, 'base64')
     writeFileSync(tmpWav, buf)
 
-    // Find whisper-cli (whisper-cpp homebrew) or whisper (python)
+    // Find whisperkit-cli (Apple CoreML) or whisper (python)
     const candidates = [
-      '/opt/homebrew/bin/whisper-cli',
-      '/usr/local/bin/whisper-cli',
+      '/opt/homebrew/bin/whisperkit-cli',
+      '/usr/local/bin/whisperkit-cli',
       '/opt/homebrew/bin/whisper',
       '/usr/local/bin/whisper',
       join(homedir(), '.local/bin/whisper'),
@@ -672,7 +672,7 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
 
     if (!whisperBin) {
       try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8' }).trim()
+        whisperBin = execSync('/bin/zsh -lc "whence -p whisperkit-cli"', { encoding: 'utf-8' }).trim()
       } catch {}
     }
     if (!whisperBin) {
@@ -683,54 +683,26 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
 
     if (!whisperBin) {
       return {
-        error: 'Whisper not found. Install with: brew install whisper-cli',
+        error: 'Whisper not found. Install with: brew install whisperkit-cli',
         transcript: null,
       }
     }
 
-    const isWhisperCpp = whisperBin.includes('whisper-cli')
+    const isWhisperKit = whisperBin.includes('whisperkit-cli')
 
-    // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
-    const modelCandidates = [
-      join(homedir(), '.local/share/whisper/ggml-base.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
-      // Fall back to English-only models if multilingual not available
-      join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
-    ]
-
-    let modelPath = ''
-    for (const m of modelCandidates) {
-      if (existsSync(m)) { modelPath = m; break }
-    }
-
-    // Detect if using an English-only model (.en suffix) — force English if so
-    const isEnglishOnly = modelPath.includes('.en.')
-    log(`Transcribing with: ${whisperBin} (model: ${modelPath || 'default'}, lang: ${isEnglishOnly ? 'en' : 'auto'})`)
+    log(`Transcribing with: ${whisperBin} (backend: ${isWhisperKit ? 'WhisperKit' : 'Python whisper'})`)
 
     let output: string
-    if (isWhisperCpp) {
-      // whisper-cpp: whisper-cli -m model -f file --no-timestamps
-      if (!modelPath) {
-        return {
-          error: 'Whisper model not found. Download with:\nmkdir -p ~/.local/share/whisper && curl -L -o ~/.local/share/whisper/ggml-tiny.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
-          transcript: null,
-        }
-      }
-      const langFlag = isEnglishOnly ? '-l en' : '-l auto'
+    if (isWhisperKit) {
+      // WhisperKit: auto-downloads CoreML models on first run
       output = execSync(
-        `"${whisperBin}" -m "${modelPath}" -f "${tmpWav}" --no-timestamps ${langFlag}`,
-        { encoding: 'utf-8', timeout: 30000 }
+        `"${whisperBin}" transcribe --audio-path "${tmpWav}" --model tiny --without-timestamps --skip-special-tokens`,
+        { encoding: 'utf-8', timeout: 60000 }
       )
     } else {
-      // Python whisper: auto-detect language unless English-only model
-      const langFlag = isEnglishOnly ? '--language en' : ''
+      // Python whisper: auto-detect language
       output = execSync(
-        `"${whisperBin}" "${tmpWav}" --model tiny ${langFlag} --output_format txt --output_dir "${tmpdir()}"`,
+        `"${whisperBin}" "${tmpWav}" --model tiny --output_format txt --output_dir "${tmpdir()}"`,
         { encoding: 'utf-8', timeout: 30000 }
       )
       // Python whisper writes .txt file
@@ -747,7 +719,7 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
       }
     }
 
-    // whisper-cpp prints to stdout directly
+    // WhisperKit prints to stdout directly
     // Strip timestamp patterns and known hallucination outputs
     const HALLUCINATIONS = /^\s*(\[BLANK_AUDIO\]|you\.?|thank you\.?|thanks\.?)\s*$/i
     const transcript = output


### PR DESCRIPTION
## Summary

The old code referenced `brew install whisper-cli`, but **`whisper-cli` never existed as a Homebrew formula**. It was an internal binary name briefly used by the whisper.cpp project (v1.7.4+), while the actual Homebrew formula has always been `whisper-cpp`.

This PR replaces all references with `whisperkit-cli` ([WhisperKit](https://github.com/argmaxinc/WhisperKit)), which is the best fit for Clui CC because:
- **Zero manual setup** — CoreML models auto-download on first run (no ggml `.bin` files to manage)
- **Native Apple Silicon** — runs on CoreML/Neural Engine, no Python or ggml dependencies
- **macOS-only anyway** — Clui CC is macOS-only, so the Apple-only constraint is a non-issue

### Alternatives considered

| Formula | Monthly installs | What it is | Models |
|---|---|---|---|
| **`whisperkit-cli`** (chosen) | 344 | Apple-native CoreML/Swift | Auto-download |
| `whisper-cpp` | 7,694 | C/C++ port (ggml) | Manual download required |
| `openai-whisper` | — | Original Python Whisper | Auto via pip/torch |

`whisper-cpp` would also work but requires users to manually download model files — a poor fit for a one-click installer.

## Changes

- **`src/main/index.ts`** — Rewrote the transcription backend:
  - Detection and path lookup now target `whisperkit-cli`
  - Invocation uses WhisperKit's CLI: `whisperkit-cli transcribe --audio-path <file> --model tiny --without-timestamps --skip-special-tokens`
  - Removed all manual ggml model file search logic (8 path candidates + download error)
  - Increased timeout from 30s → 60s for first-run model download
  - Python `whisper` fallback path preserved
- **`commands/install-app.command`** — Updated install, detection, and error hints
- **`README.md`** — Updated install instructions
- **`docs/TROUBLESHOOTING.md`** — Updated troubleshooting command
- **`docs/oss-readiness-report.md`** — Updated prerequisites reference

## Test plan
- [x] `brew install whisperkit-cli` resolves and installs (v0.17.0)
- [x] Voice transcription works end-to-end in the app
- [x] `npm run build` passes cleanly
- [x] Run `commands/install-app.command` on a clean machine