### PR TITLE
Fix Claude binary path corruption from shell integration escape sequences

### DIFF
--- a/src/main/claude/pty-run-manager.ts
+++ b/src/main/claude/pty-run-manager.ts
@@ -21,7 +21,7 @@ import { join } from 'path'
 import { execSync } from 'child_process'
 import { appendFileSync, chmodSync, existsSync, statSync } from 'fs'
 import type { NormalizedEvent, RunOptions, EnrichedError } from '../../shared/types'
-import { getCliEnv } from '../cli-env'
+import { extractAbsoluteShellPath, getCliEnv } from '../cli-env'
 
 // node-pty is a native module — require at runtime to avoid Vite bundling issues
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -312,6 +312,7 @@ export class PtyRunManager extends EventEmitter {
 
   private _findClaudeBinary(): string {
     const candidates = [
+      join(homedir(), '.local/bin/claude'),
       '/usr/local/bin/claude',
       '/opt/homebrew/bin/claude',
       join(homedir(), '.npm-global/bin/claude'),
@@ -324,12 +325,17 @@ export class PtyRunManager extends EventEmitter {
       } catch {}
     }
 
+    // Non-interactive login shell to avoid shell integration escape sequences
     try {
-      return execSync('/bin/zsh -ilc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/zsh -lc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
+      if (result) return result
     } catch {}
 
     try {
-      return execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
+      if (result) return result
     } catch {}
 
     return 'claude'

--- a/src/main/claude/run-manager.ts
+++ b/src/main/claude/run-manager.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { StreamParser } from '../stream-parser'
 import { normalize } from './event-normalizer'
 import { log as _log } from '../logger'
-import { getCliEnv } from '../cli-env'
+import { extractAbsoluteShellPath, getCliEnv } from '../cli-env'
 import type { ClaudeEvent, NormalizedEvent, RunOptions, EnrichedError } from '../../shared/types'
 
 const MAX_RING_LINES = 100
@@ -102,6 +102,7 @@ export class RunManager extends EventEmitter {
 
   private _findClaudeBinary(): string {
     const candidates = [
+      join(homedir(), '.local/bin/claude'),
       '/usr/local/bin/claude',
       '/opt/homebrew/bin/claude',
       join(homedir(), '.npm-global/bin/claude'),
@@ -114,12 +115,17 @@ export class RunManager extends EventEmitter {
       } catch {}
     }
 
+    // Non-interactive login shell to avoid shell integration escape sequences
     try {
-      return execSync('/bin/zsh -ilc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/zsh -lc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
+      if (result) return result
     } catch {}
 
     try {
-      return execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
+      if (result) return result
     } catch {}
 
     return 'claude'

--- a/src/main/cli-env.ts
+++ b/src/main/cli-env.ts
@@ -1,6 +1,38 @@
 import { execSync } from 'child_process'
+import { homedir } from 'os'
+import { join } from 'path'
 
 let cachedPath: string | null = null
+
+/**
+ * Strip terminal escape sequences (ANSI CSI, OSC, etc.) that interactive shells
+ * may emit via shell integrations (e.g. iTerm2, VS Code terminal).
+ *
+ * NOTE: similar to stripAnsi in pty-run-manager.ts but with additional
+ * patterns for bare OSC sequences common in captured shell output.
+ */
+function stripShellEscapes(str: string): string {
+  return str
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')   // CSI sequences
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '') // OSC sequences (BEL or ST terminated)
+    .replace(/\x1b[()][0-9A-Za-z]/g, '')           // character set selection
+    .replace(/\x1b[#=>\[\]]/g, '')                  // misc escapes
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '') // control chars except \n \r \t
+    .replace(/\][0-9]+;[^\x07\n]*(?:\x07)?/g, '')  // bare OSC without leading ESC (common in captured output)
+}
+
+/** Strip shell escape sequences and return the first absolute path found, or null. */
+export function extractAbsoluteShellPath(str: string): string | null {
+  const cleaned = stripShellEscapes(str).trim()
+  if (!cleaned) return null
+
+  for (const line of cleaned.split(/\r?\n/)) {
+    const candidate = line.trim()
+    if (candidate.startsWith('/')) return candidate
+  }
+
+  return null
+}
 
 function appendPathEntries(target: string[], seen: Set<string>, rawPath: string | undefined): void {
   if (!rawPath) return
@@ -21,19 +53,28 @@ export function getCliPath(): string {
   // Start from current process PATH.
   appendPathEntries(ordered, seen, process.env.PATH)
 
-  // Add common binary locations used on macOS (Homebrew + system).
-  appendPathEntries(ordered, seen, '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin')
+  // Add common binary locations used on macOS (Homebrew + system + user-local).
+  appendPathEntries(ordered, seen, [
+    join(homedir(), '.local/bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+    '/usr/sbin',
+    '/sbin',
+  ].join(':'))
 
-  // Try interactive login shell first so nvm/asdf/etc. PATH hooks are loaded.
+  // Try login shell (non-interactive) so nvm/asdf/etc. PATH hooks are loaded
+  // without triggering shell integration escape sequences.
   const pathCommands = [
-    '/bin/zsh -ilc "echo $PATH"',
     '/bin/zsh -lc "echo $PATH"',
     '/bin/bash -lc "echo $PATH"',
   ]
 
   for (const cmd of pathCommands) {
     try {
-      const discovered = execSync(cmd, { encoding: 'utf-8', timeout: 3000 }).trim()
+      const raw = execSync(cmd, { encoding: 'utf-8', timeout: 3000 })
+      const discovered = stripShellEscapes(raw).trim()
       appendPathEntries(ordered, seen, discovered)
     } catch {
       // Keep trying fallbacks.
@@ -53,4 +94,3 @@ export function getCliEnv(extraEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   delete env.CLAUDECODE
   return env
 }
-

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,7 @@ import { ControlPlane } from './claude/control-plane'
 import { ensureSkills, type SkillStatus } from './skills/installer'
 import { fetchCatalog, listInstalled, installPlugin, uninstallPlugin } from './marketplace/catalog'
 import { log as _log, LOG_FILE, flushLogs } from './logger'
-import { getCliEnv } from './cli-env'
+import { extractAbsoluteShellPath, getCliEnv } from './cli-env'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -672,12 +672,14 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
 
     if (!whisperBin) {
       try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8' }).trim()
+        const raw = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+        whisperBin = extractAbsoluteShellPath(raw) || ''
       } catch {}
     }
     if (!whisperBin) {
       try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper"', { encoding: 'utf-8' }).trim()
+        const raw = execSync('/bin/zsh -lc "whence -p whisper"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+        whisperBin = extractAbsoluteShellPath(raw) || ''
       } catch {}
     }
 

--- a/src/main/process-manager.ts
+++ b/src/main/process-manager.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 import { appendFileSync } from 'fs'
 import { join } from 'path'
 import { StreamParser } from './stream-parser'
-import { getCliEnv } from './cli-env'
+import { extractAbsoluteShellPath, getCliEnv } from './cli-env'
 import type { ClaudeEvent, RunOptions } from '../shared/types'
 
 const LOG_FILE = join(homedir(), '.clui-debug.log')
@@ -38,6 +38,7 @@ export class ProcessManager extends EventEmitter {
   private findClaudeBinary(): string {
     // Try common locations
     const candidates = [
+      join(homedir(), '.local/bin/claude'),
       '/usr/local/bin/claude',
       '/opt/homebrew/bin/claude',
       join(homedir(), '.npm-global/bin/claude'),
@@ -51,14 +52,16 @@ export class ProcessManager extends EventEmitter {
       } catch {}
     }
 
-    // Fallback: ask a login shell
+    // Non-interactive login shell to avoid shell integration escape sequences
     try {
-      const result = execSync('/bin/zsh -ilc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/zsh -lc "whence -p claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
       if (result) return result
     } catch {}
 
     try {
-      const result = execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv() }).trim()
+      const raw = execSync('/bin/bash -lc "which claude"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+      const result = extractAbsoluteShellPath(raw)
       if (result) return result
     } catch {}
 


### PR DESCRIPTION
## Problem

Clui CC silently fails to spawn Claude CLI subprocesses when the user has **terminal shell integration** enabled (iTerm2, VS Code terminal, Ghostty, etc.) and/or has Claude CLI installed at `~/.local/bin/claude`.

The app launches, the UI renders, but prompts never produce responses. There are no user-visible error messages — the debug log reveals the issue:

```
Claude binary: ]1337;RemoteHost=user@host]1337;CurrentDir=/path]1337;ShellIntegrationVersion=14;shell=zsh/Users/user/.local/bin/claude
```

The resolved binary path is contaminated with OSC escape sequences, so `spawn()` fails silently.

## Root Cause

The binary discovery fallback in `run-manager.ts`, `pty-run-manager.ts`, and `process-manager.ts` uses an **interactive** shell (`-i` flag):

```ts
execSync('/bin/zsh -ilc "whence -p claude"', ...)
```

Interactive shells source `.zshrc`, which loads shell integrations that emit escape sequences to stdout. These get concatenated with the actual binary path, producing a garbage string.

The same issue affects `cli-env.ts` PATH construction (`/bin/zsh -ilc "echo $PATH"`) and whisper binary lookup in `index.ts`.

## Who This Affects

This hits anyone with **either or both** of:

1. **A terminal emulator with shell integration** — these inject OSC escape sequences into shell stdout, contaminating any path resolved via `execSync` with a login shell:
   - iTerm2 (shell integration enabled by default)
   - VS Code integrated terminal
   - Ghostty
   - Warp, Kitty, WezTerm

2. **Claude CLI installed at `~/.local/bin/claude`** — common with newer Node/npm setups. This path wasn't in the hardcoded candidates list, forcing the shell fallback path where contamination occurs.

Terminal.app and Alacritty are not affected — they don't inject shell integration sequences.

## Changes

**`cli-env.ts`:**
- Add `~/.local/bin` to the hardcoded PATH entries
- Drop `-i` (interactive) flag from shell fallback commands
- Add `stripShellEscapes()` helper to clean residual escape sequences from shell output
- Add `extractAbsoluteShellPath()` — shared helper that strips escapes and validates the result is an absolute path

**`run-manager.ts`, `pty-run-manager.ts`, `process-manager.ts`:**
- Add `~/.local/bin/claude` to the candidates list (checked first via direct `test -x`)
- Drop `-i` flag, add `timeout: 3000` to shell fallbacks
- Use shared `extractAbsoluteShellPath()` instead of inline `.trim()`

**`index.ts`:**
- Fix whisper binary lookup (same escape contamination issue)
- Add `env: getCliEnv()` and `timeout: 3000` to whisper shell commands

## Test plan

- [x] Verified on macOS 26.4 with iTerm2 shell integration and Claude CLI at `~/.local/bin/claude`
- [x] `npm run build` passes cleanly
- [x] Debug log shows clean binary path after fix
- [x] App successfully spawns Claude subprocesses and responds to prompts
