### PR TITLE
Fix: enable manual window dragging for frameless overlay

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -239,6 +239,15 @@ ipcMain.on(IPC.SET_IGNORE_MOUSE_EVENTS, (event, ignore: boolean, options?: { for
   }
 })
 
+// Manual window drag — works reliably with frameless + setIgnoreMouseEvents
+ipcMain.on(IPC.START_WINDOW_DRAG, (event, deltaX: number, deltaY: number) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (win && !win.isDestroyed()) {
+    const [x, y] = win.getPosition()
+    win.setPosition(x + deltaX, y + deltaY)
+  }
+})
+
 // ─── IPC Handlers (typed, strict) ───
 
 ipcMain.handle(IPC.START, async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,8 @@ export interface CluiAPI {
   isVisible(): Promise<boolean>
   /** OS-level click-through for transparent window regions */
   setIgnoreMouseEvents(ignore: boolean, options?: { forward?: boolean }): void
+  /** Manual window drag for frameless windows */
+  startWindowDrag(deltaX: number, deltaY: number): void
 
   // ─── Event listeners (main → renderer) ───
   onEvent(callback: (tabId: string, event: NormalizedEvent) => void): () => void
@@ -98,6 +100,8 @@ const api: CluiAPI = {
   isVisible: () => ipcRenderer.invoke(IPC.IS_VISIBLE),
   setIgnoreMouseEvents: (ignore, options) =>
     ipcRenderer.send(IPC.SET_IGNORE_MOUSE_EVENTS, ignore, options || {}),
+  startWindowDrag: (deltaX, deltaY) =>
+    ipcRenderer.send(IPC.START_WINDOW_DRAG, deltaX, deltaY),
   setWindowWidth: (width) => ipcRenderer.send(IPC.SET_WINDOW_WIDTH, width),
 
   // ─── Event listeners ───

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Paperclip, Camera, HeadCircuit } from '@phosphor-icons/react'
 import { TabStrip } from './components/TabStrip'
@@ -88,6 +88,45 @@ export default function App() {
     return () => {
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [])
+
+  // Manual window drag — bypasses -webkit-app-region conflicts with setIgnoreMouseEvents
+  const dragRef = useRef<{ startX: number; startY: number } | null>(null)
+  useEffect(() => {
+    if (!window.clui?.startWindowDrag) return
+
+    const onMouseDown = (e: MouseEvent) => {
+      const el = e.target as HTMLElement
+      // Skip interactive elements — everything else on the card is draggable
+      if (el.closest('button, input, textarea, a, select, [role="button"], [contenteditable], .cm-editor')) return
+      if (!el.closest('[data-clui-ui]')) return
+      e.preventDefault()
+      dragRef.current = { startX: e.screenX, startY: e.screenY }
+    }
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragRef.current) return
+      const dx = e.screenX - dragRef.current.startX
+      const dy = e.screenY - dragRef.current.startY
+      if (dx !== 0 || dy !== 0) {
+        window.clui.startWindowDrag(dx, dy)
+        dragRef.current.startX = e.screenX
+        dragRef.current.startY = e.screenY
+      }
+    }
+
+    const onMouseUp = () => {
+      dragRef.current = null
+    }
+
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
     }
   }, [])
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -197,9 +197,13 @@ input::placeholder {
 .btn-stack:hover .stack-btn-3 { right: 112px; }
 
 /* ─── Drag region for frameless window ─── */
+/* Manual drag via IPC replaces -webkit-app-region which conflicts with setIgnoreMouseEvents */
 .drag-region {
-  -webkit-app-region: drag;
+  cursor: grab;
+}
+.drag-region:active {
+  cursor: grabbing;
 }
 .no-drag {
-  -webkit-app-region: no-drag;
+  cursor: default;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -340,6 +340,7 @@ export const IPC = {
   HIDE_WINDOW: 'clui:hide-window',
   WINDOW_SHOWN: 'clui:window-shown',
   SET_IGNORE_MOUSE_EVENTS: 'clui:set-ignore-mouse-events',
+  START_WINDOW_DRAG: 'clui:start-window-drag',
   IS_VISIBLE: 'clui:is-visible',
 
   // Skill provisioning (main → renderer)


### PR DESCRIPTION
## Summary

- Replaces `-webkit-app-region: drag` CSS with manual drag via IPC — the CSS approach conflicts with `setIgnoreMouseEvents` toggling on frameless transparent panels
- The entire card surface is now draggable — grab anywhere that isn't a button, input, or link
- Drag works by tracking mouse deltas and calling `BrowserWindow.setPosition()` over IPC

## Changes

| File | Change |
|------|--------|
| `src/shared/types.ts` | Add `START_WINDOW_DRAG` IPC channel |
| `src/main/index.ts` | Handle drag IPC — apply position delta to window |
| `src/preload/index.ts` | Expose `startWindowDrag` to renderer |
| `src/renderer/App.tsx` | Drag handler: mousedown on `[data-clui-ui]` starts drag, skips interactive elements |
| `src/renderer/index.css` | Replace `-webkit-app-region: drag` with `cursor: grab` |

## Root cause

`-webkit-app-region: drag` on frameless transparent windows with `setIgnoreMouseEvents(true, { forward: true })` creates an unresolvable conflict:
1. Mouse events are ignored initially for click-through
2. `{ forward: true }` forwards mousemove so the renderer can toggle events back on
3. But `-webkit-app-region: drag` intercepts mousedown at the native level before JS handlers run
4. Additionally, all children inside the card are `.no-drag`, leaving zero draggable surface pixels

The manual approach bypasses all of this by handling drag entirely in JS/IPC.

## Test plan

- [x] Drag the card by grabbing any non-interactive area (tab strip background, card edges, empty space)
- [x] Buttons, inputs, and links remain clickable (not draggable)
- [x] Click-through on transparent areas still works
- [x] Verified working on macOS Apple Silicon

Closes #26

Generated with [Claude Code](https://claude.com/claude-code)