### PR TITLE
Fix Whisper install: arch-aware backend selection with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ claude
 **Step 6.** Install Whisper for voice input:
 
 ```bash
-brew install whisper-cli
+# Apple Silicon (M1/M2/M3/M4) — preferred:
+brew install whisperkit-cli
+# Apple Silicon fallback, or Intel Mac:
+brew install whisper-cpp
 ```
 
 > **No API keys or `.env` file required.** Clui CC uses your existing Claude Code CLI authentication (Pro/Team/Enterprise subscription).

--- a/commands/install-app.command
+++ b/commands/install-app.command
@@ -35,7 +35,7 @@ fi
 
 step "Step 2/6 — Checking voice support (Whisper)"
 
-if command -v whisper-cli &>/dev/null || command -v whisper &>/dev/null; then
+if command -v whisperkit-cli &>/dev/null || command -v whisper-cli &>/dev/null || command -v whisper &>/dev/null; then
   echo "Whisper is already installed."
 else
   echo "Whisper is not installed. Voice input requires it."
@@ -52,34 +52,70 @@ else
     exit 1
   fi
 
-  echo "Installing Whisper via Homebrew..."
-  echo
-  if ! brew install whisper-cli; then
+  ARCH="$(uname -m)"
+  INSTALLED=""
+
+  if [ "$ARCH" = "arm64" ]; then
+    # Apple Silicon: prefer whisperkit-cli, fall back to whisper-cpp
+    echo "Installing Whisper via Homebrew (whisperkit-cli for $ARCH)..."
+    echo
+    if brew install whisperkit-cli; then
+      INSTALLED="whisperkit-cli"
+    else
+      echo
+      echo "whisperkit-cli failed — falling back to whisper-cpp..."
+      echo
+      if brew install whisper-cpp; then
+        INSTALLED="whisper-cpp"
+      fi
+    fi
+  else
+    # Intel: whisper-cpp only (whisperkit-cli requires arm64)
+    echo "Installing Whisper via Homebrew (whisper-cpp for $ARCH)..."
+    echo
+    if brew install whisper-cpp; then
+      INSTALLED="whisper-cpp"
+    fi
+  fi
+
+  if [ -z "$INSTALLED" ]; then
     echo
     echo "Whisper installation failed."
     echo
     echo "  Try running manually:"
-    echo "    brew install whisper-cli"
+    if [ "$ARCH" = "arm64" ]; then
+      echo "    brew install whisperkit-cli"
+      echo "  or:"
+      echo "    brew install whisper-cpp"
+    else
+      echo "    brew install whisper-cpp"
+    fi
     echo
     echo "  Then double-click this file again."
     echo
     exit 1
   fi
 
-  # Verify
-  if ! command -v whisper-cli &>/dev/null && ! command -v whisper &>/dev/null; then
+  # Verify — check for the executable that the installed formula provides
+  if [ "$INSTALLED" = "whisperkit-cli" ]; then
+    VERIFY_BIN="whisperkit-cli"
+  else
+    VERIFY_BIN="whisper-cli"
+  fi
+
+  if ! command -v "$VERIFY_BIN" &>/dev/null; then
     echo
     echo "Whisper was installed but the command is not available."
     echo
     echo "  Try opening a new Terminal window and running:"
-    echo "    whisper-cli --help"
+    echo "    $VERIFY_BIN --help"
     echo
     echo "  If that works, double-click this file again."
     echo
     exit 1
   fi
 
-  echo "Whisper installed successfully."
+  echo "Whisper installed successfully ($INSTALLED)."
 fi
 
 # ── 3. Build ──

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,7 +155,10 @@ If not, install it:
 2. Install Whisper manually:
 
 ```bash
-brew install whisper-cli
+# Apple Silicon (M1/M2/M3/M4) — preferred:
+brew install whisperkit-cli
+# Apple Silicon fallback, or Intel Mac:
+brew install whisper-cpp
 ```
 
 3. Rerun the installer:

--- a/docs/oss-readiness-report.md
+++ b/docs/oss-readiness-report.md
@@ -91,7 +91,7 @@
 - Node.js 18+ (for Electron 33)
 - macOS (primary platform — Electron transparent window, tray, node-pty)
 - `claude` CLI installed and authenticated (core dependency)
-- Optional: `whisper-cli` or `whisper` + model for voice transcription
+- Optional: `whisperkit-cli` (Apple Silicon preferred, CoreML) or `whisper-cpp` (Apple Silicon & Intel, ggml) or `whisper` (Python) for voice transcription
 
 ### Build System
 - `npm install` → `npm run dev` (hot-reload) or `npm run build` (production)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -656,8 +656,10 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     const buf = Buffer.from(audioBase64, 'base64')
     writeFileSync(tmpWav, buf)
 
-    // Find whisper-cli (whisper-cpp homebrew) or whisper (python)
+    // Find whisper backend in priority order: whisperkit-cli (Apple Silicon CoreML) → whisper-cli (whisper-cpp) → whisper (python)
     const candidates = [
+      '/opt/homebrew/bin/whisperkit-cli',
+      '/usr/local/bin/whisperkit-cli',
       '/opt/homebrew/bin/whisper-cli',
       '/usr/local/bin/whisper-cli',
       '/opt/homebrew/bin/whisper',
@@ -671,66 +673,96 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     }
 
     if (!whisperBin) {
-      try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8' }).trim()
-      } catch {}
-    }
-    if (!whisperBin) {
-      try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper"', { encoding: 'utf-8' }).trim()
-      } catch {}
+      for (const name of ['whisperkit-cli', 'whisper-cli', 'whisper']) {
+        try {
+          whisperBin = execSync(`/bin/zsh -lc "whence -p ${name}"`, { encoding: 'utf-8' }).trim()
+          if (whisperBin) break
+        } catch {}
+      }
     }
 
     if (!whisperBin) {
+      const hint = process.arch === 'arm64'
+        ? 'brew install whisperkit-cli   (or: brew install whisper-cpp)'
+        : 'brew install whisper-cpp'
       return {
-        error: 'Whisper not found. Install with: brew install whisper-cli',
+        error: `Whisper not found. Install with:\n  ${hint}`,
         transcript: null,
       }
     }
 
-    const isWhisperCpp = whisperBin.includes('whisper-cli')
+    const isWhisperKit = whisperBin.includes('whisperkit-cli')
+    const isWhisperCpp = !isWhisperKit && whisperBin.includes('whisper-cli')
 
-    // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
-    const modelCandidates = [
-      join(homedir(), '.local/share/whisper/ggml-base.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
-      // Fall back to English-only models if multilingual not available
-      join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
-    ]
-
-    let modelPath = ''
-    for (const m of modelCandidates) {
-      if (existsSync(m)) { modelPath = m; break }
-    }
-
-    // Detect if using an English-only model (.en suffix) — force English if so
-    const isEnglishOnly = modelPath.includes('.en.')
-    log(`Transcribing with: ${whisperBin} (model: ${modelPath || 'default'}, lang: ${isEnglishOnly ? 'en' : 'auto'})`)
+    log(`Transcribing with: ${whisperBin} (backend: ${isWhisperKit ? 'WhisperKit' : isWhisperCpp ? 'whisper-cpp' : 'Python whisper'})`)
 
     let output: string
-    if (isWhisperCpp) {
+    if (isWhisperKit) {
+      // WhisperKit (Apple Silicon CoreML) — auto-downloads models on first run
+      // Use --report to produce a JSON file with a top-level "text" field for deterministic parsing
+      const reportDir = tmpdir()
+      execSync(
+        `"${whisperBin}" transcribe --audio-path "${tmpWav}" --model tiny --without-timestamps --skip-special-tokens --report --report-path "${reportDir}"`,
+        { encoding: 'utf-8', timeout: 60000 }
+      )
+      // WhisperKit writes <audioFileName>.json (filename without extension)
+      const wavBasename = require('path').basename(tmpWav, '.wav')
+      const reportPath = join(reportDir, `${wavBasename}.json`)
+      if (existsSync(reportPath)) {
+        try {
+          const report = JSON.parse(readFileSync(reportPath, 'utf-8'))
+          const transcript = (report.text || '').trim()
+          try { unlinkSync(reportPath) } catch {}
+          // Also clean up .srt that --report creates
+          const srtPath = join(reportDir, `${wavBasename}.srt`)
+          try { unlinkSync(srtPath) } catch {}
+          return { error: null, transcript }
+        } catch (parseErr: any) {
+          log(`WhisperKit JSON parse failed: ${parseErr.message}, falling back to stdout`)
+          try { unlinkSync(reportPath) } catch {}
+        }
+      }
+      // Fallback: re-run without --report, stdout is plain text when --verbose is not set
+      output = execSync(
+        `"${whisperBin}" transcribe --audio-path "${tmpWav}" --model tiny --without-timestamps --skip-special-tokens`,
+        { encoding: 'utf-8', timeout: 60000 }
+      )
+    } else if (isWhisperCpp) {
       // whisper-cpp: whisper-cli -m model -f file --no-timestamps
+      // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
+      const modelCandidates = [
+        join(homedir(), '.local/share/whisper/ggml-base.bin'),
+        join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
+        '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
+        '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
+        join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
+        join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
+        '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
+        '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
+      ]
+
+      let modelPath = ''
+      for (const m of modelCandidates) {
+        if (existsSync(m)) { modelPath = m; break }
+      }
+
       if (!modelPath) {
         return {
-          error: 'Whisper model not found. Download with:\nmkdir -p ~/.local/share/whisper && curl -L -o ~/.local/share/whisper/ggml-tiny.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
+          error: 'Whisper model not found. Download with:\n  mkdir -p ~/.local/share/whisper && curl -L -o ~/.local/share/whisper/ggml-tiny.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
           transcript: null,
         }
       }
+
+      const isEnglishOnly = modelPath.includes('.en.')
       const langFlag = isEnglishOnly ? '-l en' : '-l auto'
       output = execSync(
         `"${whisperBin}" -m "${modelPath}" -f "${tmpWav}" --no-timestamps ${langFlag}`,
         { encoding: 'utf-8', timeout: 30000 }
       )
     } else {
-      // Python whisper: auto-detect language unless English-only model
-      const langFlag = isEnglishOnly ? '--language en' : ''
+      // Python whisper
       output = execSync(
-        `"${whisperBin}" "${tmpWav}" --model tiny ${langFlag} --output_format txt --output_dir "${tmpdir()}"`,
+        `"${whisperBin}" "${tmpWav}" --model tiny --output_format txt --output_dir "${tmpdir()}"`,
         { encoding: 'utf-8', timeout: 30000 }
       )
       // Python whisper writes .txt file
@@ -747,7 +779,7 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
       }
     }
 
-    // whisper-cpp prints to stdout directly
+    // WhisperKit (stdout fallback) and whisper-cpp print to stdout directly
     // Strip timestamp patterns and known hallucination outputs
     const HALLUCINATIONS = /^\s*(\[BLANK_AUDIO\]|you\.?|thank you\.?|thanks\.?)\s*$/i
     const transcript = output


### PR DESCRIPTION
## Summary

- **Fixes the broken installer**: `brew install whisper-cli` fails because `whisper-cli` is not a Homebrew formula (the binary is installed by the `whisper-cpp` formula). This broke installation for every new user.
- **Architecture-aware installer**: Apple Silicon tries `whisperkit-cli` first, falls back to `whisper-cpp` automatically. Intel installs `whisper-cpp` directly.
- **Three-backend runtime detection**: priority order `whisperkit-cli` → `whisper-cli` → `whisper` (Python), so existing installations keep working regardless of backend.
- **Deterministic WhisperKit parsing**: uses `--report` JSON output with top-level `text` field instead of fragile stdout line filtering.
- **Docs updated**: all references now show correct formula names with architecture guidance.

Supersedes #15 — takes the same root cause fix further by preserving Intel support and existing whisper-cpp installations.

Credit to @pieterdhondt for identifying the broken formula name and researching the WhisperKit alternative.

## Test plan

- [x] `bash -n commands/install-app.command` — syntax OK
- [x] `npm run build` — compiles clean
- [x] `brew install whisperkit-cli` resolves on Apple Silicon
- [x] `brew install whisper-cpp` resolves on Intel and Apple Silicon
- [x] Voice transcription works end-to-end with whisperkit-cli backend
- [x] Voice transcription works end-to-end with whisper-cpp backend
- [ ] No file references `brew install whisper-cli`