### PR TITLE
Show Edit diff content in expanded tool call view

### DIFF
--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -720,6 +720,66 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                       {desc}
                     </span>
 
+                    {/* Tool detail content for Edit/Write */}
+                    {!isRunning && tool.toolInput && (() => {
+                      try {
+                        const parsed = JSON.parse(tool.toolInput)
+                        if (toolName === 'Edit' && (parsed.old_string || parsed.new_string)) {
+                          return (
+                            <div
+                              className="mt-1 text-[11px] leading-[1.5] rounded overflow-hidden"
+                              style={{ border: `1px solid ${colors.toolBorder}` }}
+                            >
+                              {parsed.old_string && (
+                                <pre
+                                  className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                  style={{
+                                    background: 'rgba(248,81,73,0.1)',
+                                    color: colors.textSecondary,
+                                    maxHeight: 120,
+                                    margin: 0,
+                                    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
+                                    fontSize: 10,
+                                  }}
+                                >{parsed.old_string.length > 300 ? parsed.old_string.slice(0, 297) + '...' : parsed.old_string}</pre>
+                              )}
+                              {parsed.new_string && (
+                                <pre
+                                  className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                  style={{
+                                    background: 'rgba(63,185,80,0.1)',
+                                    color: colors.textSecondary,
+                                    maxHeight: 120,
+                                    margin: 0,
+                                    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
+                                    fontSize: 10,
+                                  }}
+                                >{parsed.new_string.length > 300 ? parsed.new_string.slice(0, 297) + '...' : parsed.new_string}</pre>
+                              )}
+                            </div>
+                          )
+                        }
+                        if (toolName === 'Write' && parsed.content) {
+                          const snippet = parsed.content.length > 200 ? parsed.content.slice(0, 197) + '...' : parsed.content
+                          return (
+                            <pre
+                              className="mt-1 px-2 py-1 text-[10px] leading-[1.5] rounded whitespace-pre-wrap break-all overflow-hidden"
+                              style={{
+                                background: colors.surfaceHover,
+                                color: colors.textSecondary,
+                                maxHeight: 120,
+                                margin: 0,
+                                marginTop: 4,
+                                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
+                                border: `1px solid ${colors.toolBorder}`,
+                              }}
+                            >{snippet}</pre>
+                          )
+                        }
+                      } catch { /* partial JSON */ }
+                      return null
+                    })()}
+
                     {/* Result badge */}
                     {!isRunning && (
                       <span

--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -628,28 +628,31 @@ function toolSummary(tools: Message[]): string {
   return `${desc} and ${tools.length - 1} more tool${tools.length > 2 ? 's' : ''}`
 }
 
+/** Short human-readable description from tool name + already-parsed input */
+function getToolDescriptionFromParsed(name: string, parsed: Record<string, unknown>): string {
+  switch (name) {
+    case 'Read': return `Read ${parsed.file_path || parsed.path || 'file'}`
+    case 'Edit': return `Edit ${parsed.file_path || 'file'}`
+    case 'Write': return `Write ${parsed.file_path || 'file'}`
+    case 'Glob': return `Search files: ${parsed.pattern || ''}`
+    case 'Grep': return `Search: ${parsed.pattern || ''}`
+    case 'Bash': {
+      const cmd = String(parsed.command || '')
+      return cmd.length > 60 ? `${cmd.substring(0, 57)}...` : cmd || 'Bash'
+    }
+    case 'WebSearch': return `Search: ${parsed.query || parsed.search_query || ''}`
+    case 'WebFetch': return `Fetch: ${parsed.url || ''}`
+    case 'Agent': return `Agent: ${String(parsed.prompt || parsed.description || '').substring(0, 50)}`
+    default: return name
+  }
+}
+
 /** Short human-readable description from tool name + input */
 function getToolDescription(name: string, input?: string): string {
   if (!input) return name
 
-  // Try to extract a meaningful short description from the input JSON
   try {
-    const parsed = JSON.parse(input)
-    switch (name) {
-      case 'Read': return `Read ${parsed.file_path || parsed.path || 'file'}`
-      case 'Edit': return `Edit ${parsed.file_path || 'file'}`
-      case 'Write': return `Write ${parsed.file_path || 'file'}`
-      case 'Glob': return `Search files: ${parsed.pattern || ''}`
-      case 'Grep': return `Search: ${parsed.pattern || ''}`
-      case 'Bash': {
-        const cmd = parsed.command || ''
-        return cmd.length > 60 ? `${cmd.substring(0, 57)}...` : cmd || 'Bash'
-      }
-      case 'WebSearch': return `Search: ${parsed.query || parsed.search_query || ''}`
-      case 'WebFetch': return `Fetch: ${parsed.url || ''}`
-      case 'Agent': return `Agent: ${(parsed.prompt || parsed.description || '').substring(0, 50)}`
-      default: return name
-    }
+    return getToolDescriptionFromParsed(name, JSON.parse(input))
   } catch {
     // Input is not JSON or is partial — show truncated raw
     const trimmed = input.trim()
@@ -693,7 +696,14 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
             {tools.map((tool) => {
               const isRunning = tool.toolStatus === 'running'
               const toolName = tool.toolName || 'Tool'
-              const desc = getToolDescription(toolName, tool.toolInput)
+              // Parse tool input once for both description and detail content
+              let parsedInput: Record<string, unknown> | null = null
+              if (tool.toolInput) {
+                try { parsedInput = JSON.parse(tool.toolInput) } catch { /* partial JSON */ }
+              }
+              const desc = parsedInput
+                ? getToolDescriptionFromParsed(toolName, parsedInput)
+                : getToolDescription(toolName, tool.toolInput)
 
               return (
                 <div key={tool.id} className="relative">
@@ -721,62 +731,69 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                     </span>
 
                     {/* Tool detail content for Edit/Write */}
-                    {!isRunning && tool.toolInput && (() => {
-                      try {
-                        const parsed = JSON.parse(tool.toolInput)
-                        if (toolName === 'Edit' && (parsed.old_string || parsed.new_string)) {
-                          return (
-                            <div
-                              className="mt-1 text-[11px] leading-[1.5] rounded overflow-hidden"
-                              style={{ border: `1px solid ${colors.toolBorder}` }}
-                            >
-                              {parsed.old_string && (
-                                <pre
-                                  className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
-                                  style={{
-                                    background: 'rgba(248,81,73,0.1)',
-                                    color: colors.textSecondary,
-                                    maxHeight: 120,
-                                    margin: 0,
-                                    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
-                                    fontSize: 10,
-                                  }}
-                                >{parsed.old_string.length > 300 ? parsed.old_string.slice(0, 297) + '...' : parsed.old_string}</pre>
-                              )}
-                              {parsed.new_string && (
-                                <pre
-                                  className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
-                                  style={{
-                                    background: 'rgba(63,185,80,0.1)',
-                                    color: colors.textSecondary,
-                                    maxHeight: 120,
-                                    margin: 0,
-                                    fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
-                                    fontSize: 10,
-                                  }}
-                                >{parsed.new_string.length > 300 ? parsed.new_string.slice(0, 297) + '...' : parsed.new_string}</pre>
-                              )}
-                            </div>
-                          )
-                        }
-                        if (toolName === 'Write' && parsed.content) {
-                          const snippet = parsed.content.length > 200 ? parsed.content.slice(0, 197) + '...' : parsed.content
-                          return (
-                            <pre
-                              className="mt-1 px-2 py-1 text-[10px] leading-[1.5] rounded whitespace-pre-wrap break-all overflow-hidden"
-                              style={{
-                                background: colors.surfaceHover,
-                                color: colors.textSecondary,
-                                maxHeight: 120,
-                                margin: 0,
-                                marginTop: 4,
-                                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
-                                border: `1px solid ${colors.toolBorder}`,
-                              }}
-                            >{snippet}</pre>
-                          )
-                        }
-                      } catch { /* partial JSON */ }
+                    {!isRunning && parsedInput && (() => {
+                      const monoFont = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace'
+                      if (toolName === 'Edit' && ('old_string' in parsedInput || 'new_string' in parsedInput)) {
+                        const oldStr = typeof parsedInput.old_string === 'string' ? parsedInput.old_string : null
+                        const newStr = typeof parsedInput.new_string === 'string' ? parsedInput.new_string : null
+                        if (oldStr === null && newStr === null) return null
+                        return (
+                          <div
+                            className="mt-1 text-[11px] leading-[1.5] rounded overflow-hidden"
+                            style={{ border: `1px solid ${colors.toolBorder}` }}
+                            role="group"
+                            aria-label="Edit diff"
+                          >
+                            {oldStr !== null && (
+                              <pre
+                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                aria-label="Removed"
+                                style={{
+                                  background: 'rgba(248,81,73,0.1)',
+                                  color: colors.textSecondary,
+                                  maxHeight: 120,
+                                  margin: 0,
+                                  fontFamily: monoFont,
+                                  fontSize: 10,
+                                }}
+                              ><span style={{ color: colors.textMuted, userSelect: 'none' }}>- </span>{oldStr.length > 300 ? oldStr.slice(0, 297) + '...' : oldStr}</pre>
+                            )}
+                            {newStr !== null && (
+                              <pre
+                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                aria-label="Added"
+                                style={{
+                                  background: 'rgba(63,185,80,0.1)',
+                                  color: colors.textSecondary,
+                                  maxHeight: 120,
+                                  margin: 0,
+                                  fontFamily: monoFont,
+                                  fontSize: 10,
+                                }}
+                              ><span style={{ color: colors.textMuted, userSelect: 'none' }}>+ </span>{newStr.length > 300 ? newStr.slice(0, 297) + '...' : newStr}</pre>
+                            )}
+                          </div>
+                        )
+                      }
+                      if (toolName === 'Write' && typeof parsedInput.content === 'string') {
+                        const content = parsedInput.content as string
+                        const snippet = content.length > 200 ? content.slice(0, 197) + '...' : content
+                        return (
+                          <pre
+                            className="mt-1 px-2 py-1 text-[10px] leading-[1.5] rounded whitespace-pre-wrap break-all overflow-hidden"
+                            aria-label="File content"
+                            style={{
+                              background: colors.surfaceHover,
+                              color: colors.textSecondary,
+                              maxHeight: 120,
+                              margin: 0,
+                              marginTop: 4,
+                              fontFamily: monoFont,
+                              border: `1px solid ${colors.toolBorder}`,
+                            }}
+                          >{snippet}</pre>
+                        )
+                      }
                       return null
                     })()}
 

--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -630,19 +630,20 @@ function toolSummary(tools: Message[]): string {
 
 /** Short human-readable description from tool name + already-parsed input */
 function getToolDescriptionFromParsed(name: string, parsed: Record<string, unknown>): string {
+  const s = (v: unknown) => (typeof v === 'string' ? v : '')
   switch (name) {
-    case 'Read': return `Read ${parsed.file_path || parsed.path || 'file'}`
-    case 'Edit': return `Edit ${parsed.file_path || 'file'}`
-    case 'Write': return `Write ${parsed.file_path || 'file'}`
-    case 'Glob': return `Search files: ${parsed.pattern || ''}`
-    case 'Grep': return `Search: ${parsed.pattern || ''}`
+    case 'Read': return `Read ${s(parsed.file_path) || s(parsed.path) || 'file'}`
+    case 'Edit': return `Edit ${s(parsed.file_path) || 'file'}`
+    case 'Write': return `Write ${s(parsed.file_path) || 'file'}`
+    case 'Glob': return `Search files: ${s(parsed.pattern)}`
+    case 'Grep': return `Search: ${s(parsed.pattern)}`
     case 'Bash': {
-      const cmd = String(parsed.command || '')
+      const cmd = s(parsed.command)
       return cmd.length > 60 ? `${cmd.substring(0, 57)}...` : cmd || 'Bash'
     }
-    case 'WebSearch': return `Search: ${parsed.query || parsed.search_query || ''}`
-    case 'WebFetch': return `Fetch: ${parsed.url || ''}`
-    case 'Agent': return `Agent: ${String(parsed.prompt || parsed.description || '').substring(0, 50)}`
+    case 'WebSearch': return `Search: ${s(parsed.query) || s(parsed.search_query)}`
+    case 'WebFetch': return `Fetch: ${s(parsed.url)}`
+    case 'Agent': return `Agent: ${(s(parsed.prompt) || s(parsed.description)).substring(0, 50)}`
     default: return name
   }
 }
@@ -746,7 +747,7 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                           >
                             {oldStr !== null && (
                               <pre
-                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-y-auto"
                                 aria-label="Removed"
                                 style={{
                                   background: 'rgba(248,81,73,0.1)',
@@ -760,7 +761,7 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                             )}
                             {newStr !== null && (
                               <pre
-                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-hidden"
+                                className="px-2 py-1 whitespace-pre-wrap break-all overflow-y-auto"
                                 aria-label="Added"
                                 style={{
                                   background: 'rgba(63,185,80,0.1)',
@@ -776,11 +777,11 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                         )
                       }
                       if (toolName === 'Write' && typeof parsedInput.content === 'string') {
-                        const content = parsedInput.content as string
+                        const content = parsedInput.content
                         const snippet = content.length > 200 ? content.slice(0, 197) + '...' : content
                         return (
                           <pre
-                            className="mt-1 px-2 py-1 text-[10px] leading-[1.5] rounded whitespace-pre-wrap break-all overflow-hidden"
+                            className="mt-1 px-2 py-1 text-[10px] leading-[1.5] rounded whitespace-pre-wrap break-all overflow-y-auto"
                             aria-label="File content"
                             style={{
                               background: colors.surfaceHover,

--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -750,7 +750,7 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                                 className="px-2 py-1 whitespace-pre-wrap break-all overflow-y-auto"
                                 aria-label="Removed"
                                 style={{
-                                  background: 'rgba(248,81,73,0.1)',
+                                  background: colors.diffRemovedBg,
                                   color: colors.textSecondary,
                                   maxHeight: 120,
                                   margin: 0,
@@ -764,7 +764,7 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                                 className="px-2 py-1 whitespace-pre-wrap break-all overflow-y-auto"
                                 aria-label="Added"
                                 style={{
-                                  background: 'rgba(63,185,80,0.1)',
+                                  background: colors.diffAddedBg,
                                   color: colors.textSecondary,
                                   maxHeight: 120,
                                   margin: 0,

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -134,6 +134,10 @@ const darkColors = {
   // Permission denied card
   permissionDeniedBorder: 'rgba(196, 112, 96, 0.3)',
   permissionDeniedHeaderBorder: 'rgba(196, 112, 96, 0.12)',
+
+  // Diff (Edit tool inline diff)
+  diffRemovedBg: 'rgba(248, 81, 73, 0.1)',
+  diffAddedBg: 'rgba(63, 185, 80, 0.1)',
 } as const
 
 const lightColors = {
@@ -264,6 +268,10 @@ const lightColors = {
   // Permission denied card
   permissionDeniedBorder: 'rgba(196, 112, 96, 0.3)',
   permissionDeniedHeaderBorder: 'rgba(196, 112, 96, 0.12)',
+
+  // Diff (Edit tool inline diff)
+  diffRemovedBg: 'rgba(248, 81, 73, 0.15)',
+  diffAddedBg: 'rgba(63, 185, 80, 0.15)',
 } as const
 
 export type ColorPalette = { [K in keyof typeof darkColors]: string }


### PR DESCRIPTION
## Summary
- Edit tool calls only showed "Edit /path/to/file" with a generic "Result" badge but never displayed what was actually changed
- Now shows old_string (red background) and new_string (green background) in a compact inline diff when the tool group is expanded
- Write tool calls also show a snippet of the written content
- Content is truncated (300 chars for Edit, 200 for Write) to keep the UI readable
- Gracefully handles partial/unparseable JSON from streaming

## What changed
`src/renderer/components/ConversationView.tsx` - In the expanded ToolGroup timeline, after the tool description, render a diff block for completed Edit/Write tools by parsing their `toolInput` JSON.

## Test plan
- [ ] Trigger an Edit tool call, expand the tool group, verify old/new strings are shown with red/green backgrounds
- [ ] Trigger a Write tool call, expand the tool group, verify content snippet is shown
- [ ] Verify long edits (>300 chars) are truncated with "..."
- [ ] Verify other tool types (Read, Bash, Grep) are not affected
- [ ] Verify running tools still show the spinner without diff content
- [ ] Verify collapsed tool groups still show the summary as before
- [ ] `npm run build` passes with zero errors