### PR TITLE
Add configurable overlay positions

### DIFF
--- a/commands/setup.command
+++ b/commands/setup.command
@@ -63,16 +63,9 @@ else
   fix "brew install node"
 fi
 
-# Python 3 + distutils
+# Python 3
 if command -v python3 &>/dev/null; then
   pass "Python $(python3 --version 2>&1 | awk '{print $2}')"
-
-  if python3 -c "import distutils" 2>/dev/null; then
-    pass "Python distutils available"
-  else
-    fail "Python is missing 'distutils' (needed by native module compiler)."
-    fix "python3 -m pip install --upgrade pip setuptools"
-  fi
 else
   fail "Python 3 is not installed."
   fix "brew install python@3.11"

--- a/commands/setup.command
+++ b/commands/setup.command
@@ -63,9 +63,16 @@ else
   fix "brew install node"
 fi
 
-# Python 3
+# Python 3 + distutils
 if command -v python3 &>/dev/null; then
   pass "Python $(python3 --version 2>&1 | awk '{print $2}')"
+
+  if python3 -c "import distutils" 2>/dev/null; then
+    pass "Python distutils available"
+  else
+    fail "Python is missing 'distutils' (needed by native module compiler)."
+    fix "python3 -m pip install --upgrade pip setuptools"
+  fi
 else
   fail "Python 3 is not installed."
   fix "brew install python@3.11"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,7 @@ import { fetchCatalog, listInstalled, installPlugin, uninstallPlugin } from './m
 import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getCliEnv } from './cli-env'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
+import type { RunOptions, NormalizedEvent, EnrichedError, OverlayPosition } from '../shared/types'
 
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
 const SPACES_DEBUG = DEBUG_MODE || process.env.CLUI_SPACES_DEBUG === '1'
@@ -22,6 +22,7 @@ let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let screenshotCounter = 0
 let toggleSequence = 0
+let overlayPosition: OverlayPosition = 'bottom-center'
 
 // Feature flag: enable PTY interactive permissions transport
 const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
@@ -33,6 +34,32 @@ const controlPlane = new ControlPlane(INTERACTIVE_PTY)
 const BAR_WIDTH = 1040
 const PILL_HEIGHT = 720  // Fixed native window height — extra room for expanded UI + shadow buffers
 const PILL_BOTTOM_MARGIN = 24
+const PILL_SIDE_MARGIN = 16
+
+function getAnchoredWindowBounds(display: Electron.Display): { x: number; y: number; width: number; height: number } {
+  const { width: screenWidth, height: screenHeight } = display.workAreaSize
+  const { x: dx, y: dy } = display.workArea
+
+  const x = overlayPosition === 'bottom-left'
+    ? dx + PILL_SIDE_MARGIN
+    : overlayPosition === 'bottom-right'
+      ? dx + screenWidth - BAR_WIDTH - PILL_SIDE_MARGIN
+      : dx + Math.round((screenWidth - BAR_WIDTH) / 2)
+
+  return {
+    x,
+    y: dy + screenHeight - PILL_HEIGHT - PILL_BOTTOM_MARGIN,
+    width: BAR_WIDTH,
+    height: PILL_HEIGHT,
+  }
+}
+
+function repositionWindowToCurrentDisplay(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  const cursor = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursor)
+  mainWindow.setBounds(getAnchoredWindowBounds(display))
+}
 
 // ─── Broadcast to renderer ───
 
@@ -95,15 +122,11 @@ controlPlane.on('error', (tabId: string, error: EnrichedError) => {
 function createWindow(): void {
   const cursor = screen.getCursorScreenPoint()
   const display = screen.getDisplayNearestPoint(cursor)
-  const { width: screenWidth, height: screenHeight } = display.workAreaSize
-  const { x: dx, y: dy } = display.workArea
-
-  const x = dx + Math.round((screenWidth - BAR_WIDTH) / 2)
-  const y = dy + screenHeight - PILL_HEIGHT - PILL_BOTTOM_MARGIN
+  const { x, y, width, height } = getAnchoredWindowBounds(display)
 
   mainWindow = new BrowserWindow({
-    width: BAR_WIDTH,
-    height: PILL_HEIGHT,
+    width,
+    height,
     x,
     y,
     ...(process.platform === 'darwin' ? { type: 'panel' as const } : {}),  // NSPanel — non-activating, joins all spaces
@@ -164,14 +187,7 @@ function showWindow(source = 'unknown'): void {
   // Position on the display where the cursor currently is (not always primary)
   const cursor = screen.getCursorScreenPoint()
   const display = screen.getDisplayNearestPoint(cursor)
-  const { width: sw, height: sh } = display.workAreaSize
-  const { x: dx, y: dy } = display.workArea
-  mainWindow.setBounds({
-    x: dx + Math.round((sw - BAR_WIDTH) / 2),
-    y: dy + sh - PILL_HEIGHT - PILL_BOTTOM_MARGIN,
-    width: BAR_WIDTH,
-    height: PILL_HEIGHT,
-  })
+  mainWindow.setBounds(getAnchoredWindowBounds(display))
 
   // Always re-assert space membership — the flag can be lost after hide/show cycles
   // and must be set before show() so the window joins the active Space, not its
@@ -216,6 +232,11 @@ ipcMain.on(IPC.RESIZE_HEIGHT, () => {
 
 ipcMain.on(IPC.SET_WINDOW_WIDTH, () => {
   // No-op — native width is fixed to keep expand/collapse animation smooth.
+})
+
+ipcMain.on(IPC.SET_OVERLAY_POSITION, (_event, position: OverlayPosition) => {
+  overlayPosition = position
+  repositionWindowToCurrentDisplay()
 })
 
 ipcMain.handle(IPC.ANIMATE_HEIGHT, () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ let tray: Tray | null = null
 let screenshotCounter = 0
 let toggleSequence = 0
 let overlayPosition: OverlayPosition = 'bottom-center'
+let windowBoundsAnimationTimer: ReturnType<typeof setTimeout> | null = null
 
 // Feature flag: enable PTY interactive permissions transport
 const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
@@ -35,6 +36,7 @@ const BAR_WIDTH = 1040
 const PILL_HEIGHT = 720  // Fixed native window height — extra room for expanded UI + shadow buffers
 const PILL_BOTTOM_MARGIN = 24
 const PILL_SIDE_MARGIN = 16
+const WINDOW_MOVE_DURATION_MS = 280
 
 function getAnchoredWindowBounds(display: Electron.Display): { x: number; y: number; width: number; height: number } {
   const { width: screenWidth, height: screenHeight } = display.workAreaSize
@@ -54,12 +56,67 @@ function getAnchoredWindowBounds(display: Electron.Display): { x: number; y: num
   }
 }
 
-function setWindowBounds(bounds: { x: number; y: number; width: number; height: number }, animate = false): void {
+function easeOutExpo(t: number): number {
+  if (t >= 1) return 1
+  return 1 - Math.pow(2, -10 * t)
+}
+
+function stopWindowBoundsAnimation(): void {
+  if (!windowBoundsAnimationTimer) return
+  clearTimeout(windowBoundsAnimationTimer)
+  windowBoundsAnimationTimer = null
+}
+
+function animateWindowBounds(bounds: { x: number; y: number; width: number; height: number }): void {
   if (!mainWindow || mainWindow.isDestroyed()) return
-  if (animate && process.platform === 'darwin') {
-    mainWindow.setBounds(bounds, true)
+  stopWindowBoundsAnimation()
+
+  const from = mainWindow.getBounds()
+  if (
+    from.x === bounds.x &&
+    from.y === bounds.y &&
+    from.width === bounds.width &&
+    from.height === bounds.height
+  ) {
+    mainWindow.setBounds(bounds)
     return
   }
+
+  const startedAt = Date.now()
+  const step = () => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      stopWindowBoundsAnimation()
+      return
+    }
+
+    const elapsed = Date.now() - startedAt
+    const progress = Math.min(1, elapsed / WINDOW_MOVE_DURATION_MS)
+    const eased = easeOutExpo(progress)
+
+    mainWindow.setBounds({
+      x: Math.round(from.x + (bounds.x - from.x) * eased),
+      y: Math.round(from.y + (bounds.y - from.y) * eased),
+      width: Math.round(from.width + (bounds.width - from.width) * eased),
+      height: Math.round(from.height + (bounds.height - from.height) * eased),
+    })
+
+    if (progress < 1) {
+      windowBoundsAnimationTimer = setTimeout(step, 16)
+    } else {
+      windowBoundsAnimationTimer = null
+    }
+  }
+
+  step()
+}
+
+function setWindowBounds(bounds: { x: number; y: number; width: number; height: number }, animate = false): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (animate) {
+    animateWindowBounds(bounds)
+    return
+  }
+  stopWindowBoundsAnimation()
   mainWindow.setBounds(bounds)
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,11 +54,20 @@ function getAnchoredWindowBounds(display: Electron.Display): { x: number; y: num
   }
 }
 
-function repositionWindowToCurrentDisplay(): void {
+function setWindowBounds(bounds: { x: number; y: number; width: number; height: number }, animate = false): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (animate && process.platform === 'darwin') {
+    mainWindow.setBounds(bounds, true)
+    return
+  }
+  mainWindow.setBounds(bounds)
+}
+
+function repositionWindowToCurrentDisplay(animate = false): void {
   if (!mainWindow || mainWindow.isDestroyed()) return
   const cursor = screen.getCursorScreenPoint()
   const display = screen.getDisplayNearestPoint(cursor)
-  mainWindow.setBounds(getAnchoredWindowBounds(display))
+  setWindowBounds(getAnchoredWindowBounds(display), animate)
 }
 
 // ─── Broadcast to renderer ───
@@ -187,7 +196,7 @@ function showWindow(source = 'unknown'): void {
   // Position on the display where the cursor currently is (not always primary)
   const cursor = screen.getCursorScreenPoint()
   const display = screen.getDisplayNearestPoint(cursor)
-  mainWindow.setBounds(getAnchoredWindowBounds(display))
+  setWindowBounds(getAnchoredWindowBounds(display))
 
   // Always re-assert space membership — the flag can be lost after hide/show cycles
   // and must be set before show() so the window joins the active Space, not its
@@ -236,7 +245,7 @@ ipcMain.on(IPC.SET_WINDOW_WIDTH, () => {
 
 ipcMain.on(IPC.SET_OVERLAY_POSITION, (_event, position: OverlayPosition) => {
   overlayPosition = position
-  repositionWindowToCurrentDisplay()
+  repositionWindowToCurrentDisplay(mainWindow?.isVisible() ?? false)
 })
 
 ipcMain.handle(IPC.ANIMATE_HEIGHT, () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,16 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, HealthReport, EnrichedError, Attachment, SessionMeta, CatalogPlugin, SessionLoadMessage } from '../shared/types'
+import type {
+  RunOptions,
+  NormalizedEvent,
+  HealthReport,
+  EnrichedError,
+  Attachment,
+  SessionMeta,
+  CatalogPlugin,
+  SessionLoadMessage,
+  OverlayPosition,
+} from '../shared/types'
 
 export interface CluiAPI {
   // ─── Request-response (renderer → main) ───
@@ -42,6 +52,7 @@ export interface CluiAPI {
   isVisible(): Promise<boolean>
   /** OS-level click-through for transparent window regions */
   setIgnoreMouseEvents(ignore: boolean, options?: { forward?: boolean }): void
+  setOverlayPosition(position: OverlayPosition): void
 
   // ─── Event listeners (main → renderer) ───
   onEvent(callback: (tabId: string, event: NormalizedEvent) => void): () => void
@@ -99,6 +110,7 @@ const api: CluiAPI = {
   setIgnoreMouseEvents: (ignore, options) =>
     ipcRenderer.send(IPC.SET_IGNORE_MOUSE_EVENTS, ignore, options || {}),
   setWindowWidth: (width) => ipcRenderer.send(IPC.SET_WINDOW_WIDTH, width),
+  setOverlayPosition: (position) => ipcRenderer.send(IPC.SET_OVERLAY_POSITION, position),
 
   // ─── Event listeners ───
   onEvent: (callback) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import { useSessionStore } from './stores/sessionStore'
 import { useColors, useThemeStore, spacing } from './theme'
 
 const TRANSITION = { duration: 0.26, ease: [0.4, 0, 0.1, 1] as const }
+const POSITION_SPRING = { type: 'spring' as const, stiffness: 210, damping: 24, mass: 0.9 }
 
 export default function App() {
   useClaudeEvents()
@@ -142,7 +143,10 @@ export default function App() {
             width: contentWidth,
             x: contentX,
           }}
-          transition={TRANSITION}
+          transition={{
+            width: TRANSITION,
+            x: POSITION_SPRING,
+          }}
           style={{
             position: 'relative',
             alignSelf: 'flex-start',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const colors = useColors()
   const setSystemTheme = useThemeStore((s) => s.setSystemTheme)
   const expandedUI = useThemeStore((s) => s.expandedUI)
+  const overlayPosition = useThemeStore((s) => s.overlayPosition)
 
   // ─── Theme initialization ───
   useEffect(() => {
@@ -37,6 +38,10 @@ export default function App() {
     })
     return unsub
   }, [setSystemTheme])
+
+  useEffect(() => {
+    window.clui.setOverlayPosition(overlayPosition)
+  }, [overlayPosition])
 
   useEffect(() => {
     useSessionStore.getState().initStaticInfo().then(() => {
@@ -101,6 +106,17 @@ export default function App() {
   const cardCollapsedWidth = expandedUI ? 670 : 430
   const cardCollapsedMargin = expandedUI ? 15 : 15
   const bodyMaxHeight = expandedUI ? 520 : 400
+  const contentAnchorStyle = overlayPosition === 'bottom-left'
+    ? { marginLeft: 0, marginRight: 'auto' as const }
+    : overlayPosition === 'bottom-right'
+      ? { marginLeft: 'auto' as const, marginRight: 0 }
+      : { margin: '0 auto' as const }
+  const marketplaceOffset = overlayPosition === 'bottom-left'
+    ? 0
+    : overlayPosition === 'bottom-right'
+      ? contentWidth - 720
+      : (contentWidth - 720) / 2
+  const externalButtonSide = overlayPosition === 'bottom-left' ? 'right' : 'left'
 
   const handleScreenshot = useCallback(async () => {
     const result = await window.clui.takeScreenshot()
@@ -119,7 +135,14 @@ export default function App() {
       <div className="flex flex-col justify-end h-full" style={{ background: 'transparent' }}>
 
         {/* ─── 460px content column, centered. Circles overflow left. ─── */}
-        <div style={{ width: contentWidth, position: 'relative', margin: '0 auto', transition: 'width 0.26s cubic-bezier(0.4, 0, 0.1, 1)' }}>
+        <div
+          style={{
+            width: contentWidth,
+            position: 'relative',
+            transition: 'width 0.26s cubic-bezier(0.4, 0, 0.1, 1)',
+            ...contentAnchorStyle,
+          }}
+        >
 
           <AnimatePresence initial={false}>
             {marketplaceOpen && (
@@ -128,10 +151,9 @@ export default function App() {
                 style={{
                   width: 720,
                   maxWidth: 720,
-                  marginLeft: '50%',
-                  transform: 'translateX(-50%)',
                   marginBottom: 14,
                   position: 'relative',
+                  left: marketplaceOffset,
                   zIndex: 30,
                 }}
               >
@@ -210,9 +232,9 @@ export default function App() {
             {/* Stacked circle buttons — expand on hover */}
             <div
               data-clui-ui
-              className="circles-out"
+              className={`circles-out circles-out-${externalButtonSide}`}
             >
-              <div className="btn-stack">
+              <div className={`btn-stack btn-stack-${externalButtonSide}`}>
                 {/* btn-1: Attach (front, rightmost) */}
                 <button
                   className="stack-btn stack-btn-1 glass-surface"

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -106,11 +106,12 @@ export default function App() {
   const cardCollapsedWidth = expandedUI ? 670 : 430
   const cardCollapsedMargin = expandedUI ? 15 : 15
   const bodyMaxHeight = expandedUI ? 520 : 400
-  const contentAnchorStyle = overlayPosition === 'bottom-left'
-    ? { marginLeft: 0, marginRight: 'auto' as const }
+  const viewportWidth = typeof window === 'undefined' ? 1040 : window.innerWidth
+  const contentX = overlayPosition === 'bottom-left'
+    ? 0
     : overlayPosition === 'bottom-right'
-      ? { marginLeft: 'auto' as const, marginRight: 0 }
-      : { margin: '0 auto' as const }
+      ? Math.max(0, viewportWidth - contentWidth)
+      : Math.max(0, Math.round((viewportWidth - contentWidth) / 2))
   const marketplaceOffset = overlayPosition === 'bottom-left'
     ? 0
     : overlayPosition === 'bottom-right'
@@ -135,12 +136,16 @@ export default function App() {
       <div className="flex flex-col justify-end h-full" style={{ background: 'transparent' }}>
 
         {/* ─── 460px content column, centered. Circles overflow left. ─── */}
-        <div
-          style={{
+        <motion.div
+          initial={false}
+          animate={{
             width: contentWidth,
+            x: contentX,
+          }}
+          transition={TRANSITION}
+          style={{
             position: 'relative',
-            transition: 'width 0.26s cubic-bezier(0.4, 0, 0.1, 1)',
-            ...contentAnchorStyle,
+            alignSelf: 'flex-start',
           }}
         >
 
@@ -274,7 +279,7 @@ export default function App() {
               <InputBar />
             </div>
           </div>
-        </div>
+        </motion.div>
       </div>
     </PopoverLayerProvider>
   )

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { DotsThree, Bell, ArrowsOutSimple, Moon } from '@phosphor-icons/react'
-import { useThemeStore } from '../theme'
+import { useThemeStore, type OverlayPosition } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -41,6 +41,49 @@ function RowToggle({
   )
 }
 
+function SegmentedPositionControl({
+  value,
+  onChange,
+  colors,
+}: {
+  value: OverlayPosition
+  onChange: (next: OverlayPosition) => void
+  colors: ReturnType<typeof useColors>
+}) {
+  const options: Array<{ value: OverlayPosition; label: string }> = [
+    { value: 'bottom-left', label: 'Left' },
+    { value: 'bottom-center', label: 'Center' },
+    { value: 'bottom-right', label: 'Right' },
+  ]
+
+  return (
+    <div
+      className="grid grid-cols-3 gap-1 rounded-lg p-1"
+      style={{ background: colors.surfacePrimary, border: `1px solid ${colors.containerBorder}` }}
+    >
+      {options.map((option) => {
+        const selected = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={selected}
+            className="rounded-md px-2 py-1 text-[11px] font-medium transition-colors"
+            style={{
+              background: selected ? colors.accentSoft : 'transparent',
+              color: selected ? colors.accent : colors.textSecondary,
+            }}
+            title={option.label}
+          >
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 /* ─── Settings popover ─── */
 
 export function SettingsPopover() {
@@ -50,6 +93,8 @@ export function SettingsPopover() {
   const setThemeMode = useThemeStore((s) => s.setThemeMode)
   const expandedUI = useThemeStore((s) => s.expandedUI)
   const setExpandedUI = useThemeStore((s) => s.setExpandedUI)
+  const overlayPosition = useThemeStore((s) => s.overlayPosition)
+  const setOverlayPosition = useThemeStore((s) => s.setOverlayPosition)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
@@ -151,7 +196,7 @@ export function SettingsPopover() {
             ...(pos.top != null ? { top: pos.top } : {}),
             ...(pos.bottom != null ? { bottom: pos.bottom } : {}),
             right: pos.right,
-            width: 240,
+            width: 252,
             pointerEvents: 'auto',
             background: colors.popoverBg,
             backdropFilter: 'blur(20px)',
@@ -180,6 +225,19 @@ export function SettingsPopover() {
                   label="Toggle full width panel"
                 />
               </div>
+            </div>
+
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            <div className="flex flex-col gap-2">
+              <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                Overlay position
+              </div>
+              <SegmentedPositionControl
+                value={overlayPosition}
+                onChange={setOverlayPosition}
+                colors={colors}
+              />
             </div>
 
             <div style={{ height: 1, background: colors.popoverBorder }} />

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -154,12 +154,20 @@ input::placeholder {
 /* ─── Stacking circle buttons ─── */
 .circles-out {
   position: absolute;
-  right: calc(100% + 10px);
   bottom: 0;
   height: 46px;
   display: flex;
   align-items: center;
+}
+
+.circles-out-left {
+  right: calc(100% + 10px);
   justify-content: flex-end;
+}
+
+.circles-out-right {
+  left: calc(100% + 10px);
+  justify-content: flex-start;
 }
 
 .btn-stack {
@@ -171,6 +179,7 @@ input::placeholder {
 
 .stack-btn {
   position: absolute;
+  top: 0;
   width: 46px;
   height: 46px;
   border-radius: 50%;
@@ -179,22 +188,34 @@ input::placeholder {
   justify-content: center;
   color: var(--clui-text-tertiary);
   cursor: pointer;
-  transition: right 0.4s cubic-bezier(0.34, 1.3, 0.64, 1),
+  transition: left 0.4s cubic-bezier(0.34, 1.3, 0.64, 1),
+              right 0.4s cubic-bezier(0.34, 1.3, 0.64, 1),
               color 0.15s ease,
               background 0.15s ease;
 }
 .stack-btn:hover:not(:disabled) { color: var(--clui-btn-hover-color); background: var(--clui-btn-hover-bg); }
 .stack-btn:disabled { color: var(--clui-btn-disabled); cursor: default; }
 
-/* Collapsed: stacked on the right, overlapping */
-.stack-btn-1 { right: 0;    z-index: 3; }
-.stack-btn-2 { right: 28px; z-index: 2; }
-.stack-btn-3 { right: 56px; z-index: 1; }
+/* Shared layering */
+.stack-btn-1 { z-index: 3; }
+.stack-btn-2 { z-index: 2; }
+.stack-btn-3 { z-index: 1; }
 
-/* Expanded on hover: spread evenly */
-.btn-stack:hover .stack-btn-1 { right: 0; }
-.btn-stack:hover .stack-btn-2 { right: 56px; }
-.btn-stack:hover .stack-btn-3 { right: 112px; }
+/* Default/original behavior: buttons live on the left of the input and expand further left */
+.btn-stack-left .stack-btn-1 { right: 0; z-index: 3; }
+.btn-stack-left .stack-btn-2 { right: 28px; z-index: 2; }
+.btn-stack-left .stack-btn-3 { right: 56px; z-index: 1; }
+.btn-stack-left:hover .stack-btn-1 { right: 0; }
+.btn-stack-left:hover .stack-btn-2 { right: 56px; }
+.btn-stack-left:hover .stack-btn-3 { right: 112px; }
+
+/* Left-bottom mode only: buttons move to the right of the input and expand further right */
+.btn-stack-right .stack-btn-1 { left: 0; z-index: 3; }
+.btn-stack-right .stack-btn-2 { left: 28px; z-index: 2; }
+.btn-stack-right .stack-btn-3 { left: 56px; z-index: 1; }
+.btn-stack-right:hover .stack-btn-1 { left: 0; }
+.btn-stack-right:hover .stack-btn-2 { left: 56px; }
+.btn-stack-right:hover .stack-btn-3 { left: 112px; }
 
 /* ─── Drag region for frameless window ─── */
 .drag-region {

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -3,6 +3,7 @@
  * Colors derived from ChatCN oklch system and design-fixed.html reference.
  */
 import { create } from 'zustand'
+import type { OverlayPosition } from '../shared/types'
 
 // ─── Color palettes ───
 
@@ -271,18 +272,19 @@ export type ColorPalette = { [K in keyof typeof darkColors]: string }
 // ─── Theme store ───
 
 export type ThemeMode = 'system' | 'light' | 'dark'
-
 interface ThemeState {
   isDark: boolean
   themeMode: ThemeMode
   soundEnabled: boolean
   expandedUI: boolean
+  overlayPosition: OverlayPosition
   /** OS-reported dark mode — used when themeMode is 'system' */
   _systemIsDark: boolean
   setIsDark: (isDark: boolean) => void
   setThemeMode: (mode: ThemeMode) => void
   setSoundEnabled: (enabled: boolean) => void
   setExpandedUI: (expanded: boolean) => void
+  setOverlayPosition: (position: OverlayPosition) => void
   /** Called by OS theme change listener — updates system value */
   setSystemTheme: (isDark: boolean) => void
 }
@@ -308,7 +310,12 @@ function applyTheme(isDark: boolean): void {
 
 const SETTINGS_KEY = 'clui-settings'
 
-function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean } {
+function loadSettings(): {
+  themeMode: ThemeMode
+  soundEnabled: boolean
+  expandedUI: boolean
+  overlayPosition: OverlayPosition
+} {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY)
     if (raw) {
@@ -317,13 +324,21 @@ function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expanded
         themeMode: ['light', 'dark'].includes(parsed.themeMode) ? parsed.themeMode : 'dark',
         soundEnabled: typeof parsed.soundEnabled === 'boolean' ? parsed.soundEnabled : true,
         expandedUI: typeof parsed.expandedUI === 'boolean' ? parsed.expandedUI : false,
+        overlayPosition: ['bottom-left', 'bottom-center', 'bottom-right'].includes(parsed.overlayPosition)
+          ? parsed.overlayPosition
+          : 'bottom-center',
       }
     }
   } catch {}
-  return { themeMode: 'dark', soundEnabled: true, expandedUI: false }
+  return { themeMode: 'dark', soundEnabled: true, expandedUI: false, overlayPosition: 'bottom-center' }
 }
 
-function saveSettings(s: { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean }): void {
+function saveSettings(s: {
+  themeMode: ThemeMode
+  soundEnabled: boolean
+  expandedUI: boolean
+  overlayPosition: OverlayPosition
+}): void {
   try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(s)) } catch {}
 }
 
@@ -335,6 +350,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   themeMode: saved.themeMode,
   soundEnabled: saved.soundEnabled,
   expandedUI: saved.expandedUI,
+  overlayPosition: saved.overlayPosition,
   _systemIsDark: true,
   setIsDark: (isDark) => {
     set({ isDark })
@@ -344,15 +360,39 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     const resolved = mode === 'system' ? get()._systemIsDark : mode === 'dark'
     set({ themeMode: mode, isDark: resolved })
     applyTheme(resolved)
-    saveSettings({ themeMode: mode, soundEnabled: get().soundEnabled, expandedUI: get().expandedUI })
+    saveSettings({
+      themeMode: mode,
+      soundEnabled: get().soundEnabled,
+      expandedUI: get().expandedUI,
+      overlayPosition: get().overlayPosition,
+    })
   },
   setSoundEnabled: (enabled) => {
     set({ soundEnabled: enabled })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: enabled, expandedUI: get().expandedUI })
+    saveSettings({
+      themeMode: get().themeMode,
+      soundEnabled: enabled,
+      expandedUI: get().expandedUI,
+      overlayPosition: get().overlayPosition,
+    })
   },
   setExpandedUI: (expanded) => {
     set({ expandedUI: expanded })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: get().soundEnabled, expandedUI: expanded })
+    saveSettings({
+      themeMode: get().themeMode,
+      soundEnabled: get().soundEnabled,
+      expandedUI: expanded,
+      overlayPosition: get().overlayPosition,
+    })
+  },
+  setOverlayPosition: (overlayPosition) => {
+    set({ overlayPosition })
+    saveSettings({
+      themeMode: get().themeMode,
+      soundEnabled: get().soundEnabled,
+      expandedUI: get().expandedUI,
+      overlayPosition,
+    })
   },
   setSystemTheme: (isDark) => {
     set({ _systemIsDark: isDark })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -275,6 +275,8 @@ export interface SessionLoadMessage {
   timestamp: number
 }
 
+export type OverlayPosition = 'bottom-left' | 'bottom-center' | 'bottom-right'
+
 // ─── Marketplace / Plugin Types ───
 
 export type PluginStatus = 'not_installed' | 'checking' | 'installing' | 'installed' | 'failed'
@@ -341,6 +343,7 @@ export const IPC = {
   WINDOW_SHOWN: 'clui:window-shown',
   SET_IGNORE_MOUSE_EVENTS: 'clui:set-ignore-mouse-events',
   IS_VISIBLE: 'clui:is-visible',
+  SET_OVERLAY_POSITION: 'clui:set-overlay-position',
 
   // Skill provisioning (main → renderer)
   SKILL_STATUS: 'clui:skill-status',


### PR DESCRIPTION
## Summary
- add a settings control for bottom-left, bottom-center, and bottom-right overlay placement
- anchor the Electron window to the current screen edge for left/right modes and mirror the external button layout only for bottom-left
- persist the overlay position setting and wire renderer updates through preload/main IPC
- animate overlay position changes with coordinated native window and renderer transitions so moves between placements feel smooth and polished

## Verification
- npm run build
- CSC_IDENTITY_AUTO_DISCOVERY=false npm run dist
- installed and launched /Applications/Clui CC.app