### PR TITLE
Add window opacity setting

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -312,6 +312,13 @@ ipcMain.on(IPC.RESET_WINDOW_POSITION, () => {
   resetWindowPosition()
 })
 
+// Set native window opacity (0.0–1.0)
+ipcMain.on(IPC.SET_WINDOW_OPACITY, (_event, opacity: number) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.setOpacity(Math.max(0.2, Math.min(1, opacity)))
+  }
+})
+
 // ─── IPC Handlers (typed, strict) ───
 
 ipcMain.handle(IPC.START, async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,8 @@ export interface CluiAPI {
   startWindowDrag(deltaX: number, deltaY: number): void
   /** Reset overlay to its default bottom-center position */
   resetWindowPosition(): void
+  /** Set native window opacity (0.0–1.0) */
+  setWindowOpacity(opacity: number): void
 
   // ─── Event listeners (main → renderer) ───
   onEvent(callback: (tabId: string, event: NormalizedEvent) => void): () => void
@@ -105,6 +107,7 @@ const api: CluiAPI = {
   startWindowDrag: (deltaX, deltaY) =>
     ipcRenderer.send(IPC.START_WINDOW_DRAG, deltaX, deltaY),
   resetWindowPosition: () => ipcRenderer.send(IPC.RESET_WINDOW_POSITION),
+  setWindowOpacity: (opacity) => ipcRenderer.send(IPC.SET_WINDOW_OPACITY, opacity),
   setWindowWidth: (width) => ipcRenderer.send(IPC.SET_WINDOW_WIDTH, width),
 
   // ─── Event listeners ───

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { DotsThree, Bell, ArrowsOutSimple, Moon } from '@phosphor-icons/react'
+import { DotsThree, Bell, ArrowsOutSimple, Moon, Drop } from '@phosphor-icons/react'
 import { useThemeStore } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
@@ -50,6 +50,8 @@ export function SettingsPopover() {
   const setThemeMode = useThemeStore((s) => s.setThemeMode)
   const expandedUI = useThemeStore((s) => s.expandedUI)
   const setExpandedUI = useThemeStore((s) => s.setExpandedUI)
+  const windowOpacity = useThemeStore((s) => s.windowOpacity)
+  const setWindowOpacity = useThemeStore((s) => s.setWindowOpacity)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
@@ -219,6 +221,35 @@ export function SettingsPopover() {
                   colors={colors}
                   label="Toggle dark theme"
                 />
+              </div>
+            </div>
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            {/* Window opacity */}
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Drop size={14} style={{ color: colors.textTertiary }} />
+                  <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                    Opacity
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="range"
+                    min={20}
+                    max={100}
+                    step={5}
+                    value={windowOpacity}
+                    onChange={(e) => setWindowOpacity(Number(e.target.value))}
+                    className="w-16 h-1 accent-current cursor-pointer"
+                    style={{ accentColor: colors.accent }}
+                    aria-label="Window opacity"
+                  />
+                  <div className="text-[11px] w-7 text-right tabular-nums" style={{ color: colors.textTertiary }}>
+                    {windowOpacity}%
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -285,12 +285,15 @@ interface ThemeState {
   themeMode: ThemeMode
   soundEnabled: boolean
   expandedUI: boolean
+  /** Window opacity 0–100 (percent). Default 100 (fully opaque). */
+  windowOpacity: number
   /** OS-reported dark mode — used when themeMode is 'system' */
   _systemIsDark: boolean
   setIsDark: (isDark: boolean) => void
   setThemeMode: (mode: ThemeMode) => void
   setSoundEnabled: (enabled: boolean) => void
   setExpandedUI: (expanded: boolean) => void
+  setWindowOpacity: (opacity: number) => void
   /** Called by OS theme change listener — updates system value */
   setSystemTheme: (isDark: boolean) => void
 }
@@ -316,7 +319,7 @@ function applyTheme(isDark: boolean): void {
 
 const SETTINGS_KEY = 'clui-settings'
 
-function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean } {
+function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean; windowOpacity: number } {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY)
     if (raw) {
@@ -325,14 +328,19 @@ function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expanded
         themeMode: ['light', 'dark'].includes(parsed.themeMode) ? parsed.themeMode : 'dark',
         soundEnabled: typeof parsed.soundEnabled === 'boolean' ? parsed.soundEnabled : true,
         expandedUI: typeof parsed.expandedUI === 'boolean' ? parsed.expandedUI : false,
+        windowOpacity: typeof parsed.windowOpacity === 'number' ? Math.max(20, Math.min(100, parsed.windowOpacity)) : 100,
       }
     }
   } catch {}
-  return { themeMode: 'dark', soundEnabled: true, expandedUI: false }
+  return { themeMode: 'dark', soundEnabled: true, expandedUI: false, windowOpacity: 100 }
 }
 
-function saveSettings(s: { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean }): void {
+function saveSettings(s: { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean; windowOpacity: number }): void {
   try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(s)) } catch {}
+}
+
+function currentSettings(get: () => ThemeState) {
+  return { themeMode: get().themeMode, soundEnabled: get().soundEnabled, expandedUI: get().expandedUI, windowOpacity: get().windowOpacity }
 }
 
 // Always start in compact UI mode on launch.
@@ -343,6 +351,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   themeMode: saved.themeMode,
   soundEnabled: saved.soundEnabled,
   expandedUI: saved.expandedUI,
+  windowOpacity: saved.windowOpacity,
   _systemIsDark: true,
   setIsDark: (isDark) => {
     set({ isDark })
@@ -352,15 +361,21 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     const resolved = mode === 'system' ? get()._systemIsDark : mode === 'dark'
     set({ themeMode: mode, isDark: resolved })
     applyTheme(resolved)
-    saveSettings({ themeMode: mode, soundEnabled: get().soundEnabled, expandedUI: get().expandedUI })
+    saveSettings({ ...currentSettings(get), themeMode: mode })
   },
   setSoundEnabled: (enabled) => {
     set({ soundEnabled: enabled })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: enabled, expandedUI: get().expandedUI })
+    saveSettings({ ...currentSettings(get), soundEnabled: enabled })
   },
   setExpandedUI: (expanded) => {
     set({ expandedUI: expanded })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: get().soundEnabled, expandedUI: expanded })
+    saveSettings({ ...currentSettings(get), expandedUI: expanded })
+  },
+  setWindowOpacity: (opacity) => {
+    const clamped = Math.max(20, Math.min(100, Math.round(opacity)))
+    set({ windowOpacity: clamped })
+    saveSettings({ ...currentSettings(get), windowOpacity: clamped })
+    ;(window as any).clui?.setWindowOpacity(clamped / 100)
   },
   setSystemTheme: (isDark) => {
     set({ _systemIsDark: isDark })
@@ -374,6 +389,11 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 
 // Initialize CSS vars with saved theme
 syncTokensToCss(saved.themeMode === 'light' ? lightColors : darkColors)
+
+// Apply saved window opacity on startup
+if (saved.windowOpacity < 100) {
+  ;(window as any).clui?.setWindowOpacity(saved.windowOpacity / 100)
+}
 
 /** Reactive hook — returns the active color palette */
 export function useColors(): ColorPalette {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -342,6 +342,7 @@ export const IPC = {
   SET_IGNORE_MOUSE_EVENTS: 'clui:set-ignore-mouse-events',
   START_WINDOW_DRAG: 'clui:start-window-drag',
   RESET_WINDOW_POSITION: 'clui:reset-window-position',
+  SET_WINDOW_OPACITY: 'clui:set-window-opacity',
   IS_VISIBLE: 'clui:is-visible',
 
   // Skill provisioning (main → renderer)


### PR DESCRIPTION
## Summary

- Adds a **window opacity slider** (20–100%) to the Settings popover, allowing users to make the overlay translucent
- Opacity is persisted in localStorage and restored on startup via `BrowserWindow.setOpacity()`
- Introduces `SET_WINDOW_OPACITY` IPC channel with proper clamping (0.2–1.0)
- Refactors `saveSettings()` calls to use a `currentSettings()` helper, reducing repetition

## Details

- **`src/shared/types.ts`** — new `SET_WINDOW_OPACITY` IPC constant
- **`src/main/index.ts`** — IPC listener calling `mainWindow.setOpacity()`
- **`src/preload/index.ts`** — exposes `setWindowOpacity()` on the `CluiAPI` bridge
- **`src/renderer/theme.ts`** — `windowOpacity` state in Zustand store, persistence, startup restore
- **`src/renderer/components/SettingsPopover.tsx`** — opacity slider UI with Drop icon

## Test plan

- [ ] Launch app → verify default opacity is 100%
- [ ] Drag slider to ~60% → window becomes translucent
- [ ] Quit and relaunch → opacity persists at 60%
- [ ] Set back to 100% → fully opaque
- [ ] Verify slider range is clamped between 20% and 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)