### PR TITLE
Fix session history not found for usernames containing dots

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -429,8 +429,8 @@ ipcMain.handle(IPC.LIST_SESSIONS, async (_e, projectPath?: string) => {
       return []
     }
     // Claude stores project sessions at ~/.claude/projects/<encoded-path>/
-    // Path encoding: replace all '/' with '-' (leading '/' becomes leading '-')
-    const encodedPath = cwd.replace(/\//g, '-')
+    // Path encoding: replace '/' and '.' with '-' (matches Claude Code's encoding)
+    const encodedPath = cwd.replace(/[/.]/g, '-')
     const sessionsDir = join(homedir(), '.claude', 'projects', encodedPath)
     if (!existsSync(sessionsDir)) {
       log(`LIST_SESSIONS: directory not found: ${sessionsDir}`)
@@ -523,7 +523,7 @@ ipcMain.handle(IPC.LOAD_SESSION, async (_e, arg: { sessionId: string; projectPat
       log(`LOAD_SESSION: rejected invalid projectPath: ${cwd}`)
       return []
     }
-    const encodedPath = cwd.replace(/\//g, '-')
+    const encodedPath = cwd.replace(/[/.]/g, '-')
     const filePath = join(homedir(), '.claude', 'projects', encodedPath, `${sessionId}.jsonl`)
     if (!existsSync(filePath)) return []
 


### PR DESCRIPTION
## Summary

- Fix path encoding in `listSessions` and `loadSession` to replace both `/` and `.` with `-`, matching Claude Code's actual encoding
- Without this fix, users whose OS username contains a dot (e.g. `john.doe`) can never see session history

## Root Cause

Claude Code encodes project paths like:
```
/Users/john.doe/Dev/project → -Users-john-doe-Dev-project
```

CLUI only replaced `/` → `-`, producing `-Users-john.doe-Dev-project`, which doesn't match the directory on disk.

## Changes

`src/main/index.ts`: Changed `cwd.replace(/\//g, '-')` → `cwd.replace(/[/.]/g, '-')` in both `LIST_SESSIONS` and `LOAD_SESSION` handlers.

Fixes #53

## Test plan

- [x] Verified the actual `.claude/projects/` directory naming uses `-` for dots
- [x] Confirmed from debug logs that the old encoding produced a non-matching path
- [ ] Manual test: select a project directory → click History → sessions now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)