### PR TITLE
Improve overlay UX: selection, drag, settings persistence, models, and iTerm CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -733,72 +733,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -3491,15 +3425,6 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
-    },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7280,36 +7205,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
     },
     "node_modules/proc-log": {
       "version": "5.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,6 +58,60 @@ let tray: Tray | null = null
 let screenshotCounter = 0
 let toggleSequence = 0
 let lastWindowBounds: Electron.Rectangle | null = null
+let currentZoomFactor = 1.0
+
+// ─── Zoom persistence ───
+
+function zoomFilePath(): string {
+  return join(app.getPath('userData'), 'clui-zoom.json')
+}
+
+function loadSavedZoom(): number {
+  try {
+    const { readFileSync } = require('fs')
+    const raw = readFileSync(zoomFilePath(), 'utf-8')
+    const parsed = JSON.parse(raw)
+    const factor = parsed.factor
+    if (typeof factor === 'number' && factor >= 0.7 && factor <= 1.5) return factor
+  } catch {}
+  return 1.0
+}
+
+function persistZoom(factor: number): void {
+  try {
+    const { writeFileSync, mkdirSync } = require('fs')
+    mkdirSync(app.getPath('userData'), { recursive: true })
+    writeFileSync(zoomFilePath(), JSON.stringify({ factor }))
+  } catch {}
+}
+
+function applyZoom(factor: number): void {
+  currentZoomFactor = Math.round(factor * 10) / 10
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    persistZoom(currentZoomFactor)
+    return
+  }
+
+  mainWindow.webContents.setZoomFactor(currentZoomFactor)
+
+  // Scale native window so CSS viewport stays constant width — prevents circle overflow
+  const scaledWidth = Math.round(BAR_WIDTH * currentZoomFactor)
+  const scaledHeight = Math.round(PILL_HEIGHT * currentZoomFactor)
+
+  const cursor = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursor)
+  const { width: sw, height: sh } = display.workAreaSize
+  const { x: dx, y: dy } = display.workArea
+
+  mainWindow.setBounds({
+    width: scaledWidth,
+    height: scaledHeight,
+    x: dx + Math.round((sw - scaledWidth) / 2),
+    y: dy + sh - scaledHeight - PILL_BOTTOM_MARGIN,
+  })
+  lastWindowBounds = mainWindow.getBounds()
+  persistZoom(currentZoomFactor)
+}
 
 // Feature flag: enable PTY interactive permissions transport
 const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
@@ -134,12 +188,14 @@ function createWindow(): void {
   const { width: screenWidth, height: screenHeight } = display.workAreaSize
   const { x: dx, y: dy } = display.workArea
 
-  const x = dx + Math.round((screenWidth - BAR_WIDTH) / 2)
-  const y = dy + screenHeight - PILL_HEIGHT - PILL_BOTTOM_MARGIN
+  const scaledWidth = Math.round(BAR_WIDTH * currentZoomFactor)
+  const scaledHeight = Math.round(PILL_HEIGHT * currentZoomFactor)
+  const x = dx + Math.round((screenWidth - scaledWidth) / 2)
+  const y = dy + screenHeight - scaledHeight - PILL_BOTTOM_MARGIN
 
   mainWindow = new BrowserWindow({
-    width: BAR_WIDTH,
-    height: PILL_HEIGHT,
+    width: scaledWidth,
+    height: scaledHeight,
     x,
     y,
     ...(process.platform === 'darwin' ? { type: 'panel' as const } : {}),  // NSPanel — non-activating, joins all spaces
@@ -176,12 +232,30 @@ function createWindow(): void {
 
   mainWindow.once('ready-to-show', () => {
     mainWindow?.show()
-    // Enable OS-level click-through for transparent regions.
-    // { forward: true } ensures mousemove events still reach the renderer
-    // so it can toggle click-through off when cursor enters interactive UI.
     mainWindow?.setIgnoreMouseEvents(true, { forward: true })
+    // Restore saved zoom factor
+    if (currentZoomFactor !== 1.0 && mainWindow) {
+      mainWindow.webContents.setZoomFactor(currentZoomFactor)
+    }
     if (process.env.ELECTRON_RENDERER_URL) {
       mainWindow?.webContents.openDevTools({ mode: 'detach' })
+    }
+  })
+
+  // Intercept Cmd++/Cmd+-/Cmd+0 to manage zoom + window resize together
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return
+    const isMod = input.meta || input.control
+    if (!isMod || input.alt) return
+    if (input.key === '=' || input.key === '+') {
+      event.preventDefault()
+      applyZoom(Math.min(1.5, currentZoomFactor + 0.1))
+    } else if (input.key === '-') {
+      event.preventDefault()
+      applyZoom(Math.max(0.7, currentZoomFactor - 0.1))
+    } else if (input.key === '0') {
+      event.preventDefault()
+      applyZoom(1.0)
     }
   })
 
@@ -238,11 +312,14 @@ function resetWindowPosition(): void {
   const { width: sw, height: sh } = display.workAreaSize
   const { x: dx, y: dy } = display.workArea
 
+  const scaledWidth = Math.round(BAR_WIDTH * currentZoomFactor)
+  const scaledHeight = Math.round(PILL_HEIGHT * currentZoomFactor)
+
   mainWindow.setBounds({
-    x: dx + Math.round((sw - BAR_WIDTH) / 2),
-    y: dy + sh - PILL_HEIGHT - PILL_BOTTOM_MARGIN,
-    width: BAR_WIDTH,
-    height: PILL_HEIGHT,
+    x: dx + Math.round((sw - scaledWidth) / 2),
+    y: dy + sh - scaledHeight - PILL_BOTTOM_MARGIN,
+    width: scaledWidth,
+    height: scaledHeight,
   })
   lastWindowBounds = mainWindow.getBounds()
 }
@@ -1100,6 +1177,9 @@ app.whenReady().then(async () => {
   await requestPermissions()
 
   installContentSecurityPolicy()
+
+  // Restore saved zoom before window creation so initial dimensions are correct
+  currentZoomFactor = loadSavedZoom()
 
   // Skill provisioning — non-blocking, streams status to renderer
   ensureSkills((status: SkillStatus) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { fetchCatalog, listInstalled, installPlugin, uninstallPlugin } from './m
 import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getCliEnv } from './cli-env'
 import { IPC } from '../shared/types'
+import { getSessionModel, setSessionModel } from './session-models'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
@@ -578,6 +579,31 @@ ipcMain.handle(IPC.LIST_SESSIONS, async (_e, projectPath?: string) => {
     log(`LIST_SESSIONS error: ${err}`)
     return []
   }
+})
+
+const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function validateSessionProjectPath(projectPath?: string): string | null {
+  const cwd = projectPath || process.cwd()
+  if (/[\0\r\n]/.test(cwd) || !cwd.startsWith('/')) return null
+  return cwd
+}
+
+ipcMain.handle(IPC.GET_SESSION_MODEL, (_e, arg: { sessionId: string; projectPath?: string }) => {
+  const { sessionId, projectPath } = arg
+  if (!SESSION_UUID_RE.test(sessionId)) return null
+  const cwd = validateSessionProjectPath(projectPath)
+  if (!cwd) return null
+  return getSessionModel(cwd, sessionId)
+})
+
+ipcMain.handle(IPC.SET_SESSION_MODEL, (_e, arg: { sessionId: string; projectPath?: string; modelId: string | null }) => {
+  const { sessionId, projectPath, modelId } = arg
+  if (!SESSION_UUID_RE.test(sessionId)) return false
+  const cwd = validateSessionProjectPath(projectPath)
+  if (!cwd) return false
+  setSessionModel(cwd, sessionId, modelId)
+  return true
 })
 
 // Load conversation history from a session's JSONL file

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,8 @@ import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getCliEnv } from './cli-env'
 import { IPC } from '../shared/types'
 import { getSessionModel, setSessionModel } from './session-models'
+import { buildCliCommand, buildOpenTerminalAppleScript } from './open-terminal'
+import type { CliTerminalApp } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
@@ -1072,63 +1074,50 @@ ipcMain.handle(IPC.GET_DIAGNOSTICS, () => {
   }
 })
 
-ipcMain.handle(IPC.OPEN_IN_TERMINAL, (_event, arg: string | null | { sessionId?: string | null; projectPath?: string }) => {
+ipcMain.handle(IPC.OPEN_IN_TERMINAL, (_event, arg: string | null | { sessionId?: string | null; projectPath?: string; terminalApp?: CliTerminalApp }) => {
   const { execFile } = require('child_process')
-  const claudeBin = 'claude'
+
+  if (process.platform !== 'darwin') {
+    log('OPEN_IN_TERMINAL: only supported on macOS')
+    return false
+  }
 
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-  // Support both old (string) and new ({ sessionId, projectPath }) calling convention
   let sessionId: string | null = null
   let projectPath: string = process.cwd()
+  let terminalApp: CliTerminalApp = 'terminal'
   if (typeof arg === 'string') {
     sessionId = arg
   } else if (arg && typeof arg === 'object') {
     sessionId = arg.sessionId ?? null
     projectPath = arg.projectPath && arg.projectPath !== '~' ? arg.projectPath : process.cwd()
+    if (arg.terminalApp === 'iterm' || arg.terminalApp === 'terminal') {
+      terminalApp = arg.terminalApp
+    }
   }
 
-  // Validate sessionId — must be a strict UUID to prevent injection into the shell command
   if (sessionId && !UUID_RE.test(sessionId)) {
     log(`OPEN_IN_TERMINAL: rejected invalid sessionId: ${sessionId}`)
     return false
   }
 
-  // Sanitize projectPath — reject null bytes, newlines, and non-absolute paths
   if (/[\0\r\n]/.test(projectPath) || !projectPath.startsWith('/')) {
     log(`OPEN_IN_TERMINAL: rejected invalid projectPath: ${projectPath}`)
     return false
   }
 
-  // Shell-safe single-quote escaping: replace ' with '\'' (end quote, escaped literal quote, reopen quote)
-  // Single quotes block all shell expansion ($, `, \, etc.) — unlike double quotes which allow $() and backticks
-  const shellSingleQuote = (s: string): string => "'" + s.replace(/'/g, "'\\''") + "'"
-  // AppleScript string escaping: backslashes doubled, double quotes escaped
-  const escapeAppleScript = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-
-  const safeDir = escapeAppleScript(shellSingleQuote(projectPath))
-
-  let cmd: string
-  if (sessionId) {
-    // sessionId is UUID-validated above, safe to embed directly
-    cmd = `cd ${safeDir} && ${claudeBin} --resume ${sessionId}`
-  } else {
-    cmd = `cd ${safeDir} && ${claudeBin}`
-  }
-
-  const script = `tell application "Terminal"
-  activate
-  do script "${cmd}"
-end tell`
+  const cmd = buildCliCommand(projectPath, sessionId)
+  const script = buildOpenTerminalAppleScript(terminalApp, cmd)
 
   try {
     execFile('/usr/bin/osascript', ['-e', script], (err: Error | null) => {
-      if (err) log(`Failed to open terminal: ${err.message}`)
-      else log(`Opened terminal with: ${cmd}`)
+      if (err) log(`Failed to open ${terminalApp}: ${err.message}`)
+      else log(`Opened ${terminalApp} with: ${cmd}`)
     })
     return true
   } catch (err: unknown) {
-    log(`Failed to open terminal: ${err}`)
+    log(`Failed to open ${terminalApp}: ${err}`)
     return false
   }
 })

--- a/src/main/open-terminal.ts
+++ b/src/main/open-terminal.ts
@@ -1,0 +1,36 @@
+import type { CliTerminalApp } from '../shared/types'
+
+/** Escape a string for embedding inside an AppleScript double-quoted literal */
+export function escapeAppleScript(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+/** Shell-safe single-quote escaping for paths/commands passed to the shell */
+export function shellSingleQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'"
+}
+
+export function buildCliCommand(projectPath: string, sessionId: string | null, claudeBin = 'claude'): string {
+  const safeDir = shellSingleQuote(projectPath)
+  if (sessionId) {
+    return `cd ${safeDir} && ${claudeBin} --resume ${sessionId}`
+  }
+  return `cd ${safeDir} && ${claudeBin}`
+}
+
+export function buildOpenTerminalAppleScript(terminalApp: CliTerminalApp, cmd: string): string {
+  const escaped = escapeAppleScript(cmd)
+  if (terminalApp === 'iterm') {
+    return `tell application "iTerm"
+  activate
+  set newWindow to (create window with default profile)
+  tell current session of newWindow
+    write text "${escaped}"
+  end tell
+end tell`
+  }
+  return `tell application "Terminal"
+  activate
+  do script "${escaped}"
+end tell`
+}

--- a/src/main/session-models.ts
+++ b/src/main/session-models.ts
@@ -1,0 +1,46 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+
+/** Claude encodes project paths as ~/.claude/projects/<path-with-slashes-as-dashes>/ */
+export function encodeProjectPath(projectPath: string): string {
+  const cwd = projectPath === '~' ? homedir() : projectPath
+  return cwd.replace(/\//g, '-')
+}
+
+function modelsFilePath(projectPath: string): string {
+  return join(homedir(), '.claude', 'projects', encodeProjectPath(projectPath), 'clui-models.json')
+}
+
+export function getSessionModel(projectPath: string, sessionId: string): string | null {
+  try {
+    const filePath = modelsFilePath(projectPath)
+    if (!existsSync(filePath)) return null
+    const data = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>
+    const model = data[sessionId]
+    return typeof model === 'string' ? model : null
+  } catch {
+    return null
+  }
+}
+
+export function setSessionModel(projectPath: string, sessionId: string, modelId: string | null): void {
+  const filePath = modelsFilePath(projectPath)
+  mkdirSync(dirname(filePath), { recursive: true })
+
+  let data: Record<string, string> = {}
+  try {
+    if (existsSync(filePath)) {
+      const parsed = JSON.parse(readFileSync(filePath, 'utf-8'))
+      if (parsed && typeof parsed === 'object') data = parsed as Record<string, string>
+    }
+  } catch {}
+
+  if (modelId) {
+    data[sessionId] = modelId
+  } else {
+    delete data[sessionId]
+  }
+
+  writeFileSync(filePath, JSON.stringify(data, null, 2))
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, HealthReport, EnrichedError, Attachment, SessionMeta, CatalogPlugin, SessionLoadMessage } from '../shared/types'
+import type { RunOptions, NormalizedEvent, HealthReport, EnrichedError, Attachment, SessionMeta, CatalogPlugin, SessionLoadMessage, CliTerminalApp } from '../shared/types'
 
 export interface CluiAPI {
   // ─── Request-response (renderer → main) ───
@@ -15,7 +15,7 @@ export interface CluiAPI {
   closeTab(tabId: string): Promise<void>
   selectDirectory(): Promise<string | null>
   openExternal(url: string): Promise<boolean>
-  openInTerminal(sessionId: string | null, projectPath?: string): Promise<boolean>
+  openInTerminal(sessionId: string | null, projectPath?: string, terminalApp?: CliTerminalApp): Promise<boolean>
   attachFiles(): Promise<Attachment[] | null>
   takeScreenshot(): Promise<Attachment | null>
   pasteImage(dataUrl: string): Promise<Attachment | null>
@@ -70,7 +70,8 @@ const api: CluiAPI = {
   closeTab: (tabId) => ipcRenderer.invoke(IPC.CLOSE_TAB, tabId),
   selectDirectory: () => ipcRenderer.invoke(IPC.SELECT_DIRECTORY),
   openExternal: (url) => ipcRenderer.invoke(IPC.OPEN_EXTERNAL, url),
-  openInTerminal: (sessionId, projectPath) => ipcRenderer.invoke(IPC.OPEN_IN_TERMINAL, { sessionId, projectPath }),
+  openInTerminal: (sessionId, projectPath, terminalApp) =>
+    ipcRenderer.invoke(IPC.OPEN_IN_TERMINAL, { sessionId, projectPath, terminalApp }),
   attachFiles: () => ipcRenderer.invoke(IPC.ATTACH_FILES),
   takeScreenshot: () => ipcRenderer.invoke(IPC.TAKE_SCREENSHOT),
   pasteImage: (dataUrl) => ipcRenderer.invoke(IPC.PASTE_IMAGE, dataUrl),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,8 @@ export interface CluiAPI {
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
   loadSession(sessionId: string, projectPath?: string): Promise<SessionLoadMessage[]>
+  getSessionModel(sessionId: string, projectPath?: string): Promise<string | null>
+  setSessionModel(sessionId: string, projectPath: string | undefined, modelId: string | null): Promise<boolean>
   fetchMarketplace(forceRefresh?: boolean): Promise<{ plugins: CatalogPlugin[]; error: string | null }>
   listInstalledPlugins(): Promise<string[]>
   installPlugin(repo: string, pluginName: string, marketplace: string, sourcePath?: string, isSkillMd?: boolean): Promise<{ ok: boolean; error?: string }>
@@ -80,6 +82,9 @@ const api: CluiAPI = {
   resetTabSession: (tabId) => ipcRenderer.send(IPC.RESET_TAB_SESSION, tabId),
   listSessions: (projectPath?: string) => ipcRenderer.invoke(IPC.LIST_SESSIONS, projectPath),
   loadSession: (sessionId: string, projectPath?: string) => ipcRenderer.invoke(IPC.LOAD_SESSION, { sessionId, projectPath }),
+  getSessionModel: (sessionId, projectPath) => ipcRenderer.invoke(IPC.GET_SESSION_MODEL, { sessionId, projectPath }),
+  setSessionModel: (sessionId, projectPath, modelId) =>
+    ipcRenderer.invoke(IPC.SET_SESSION_MODEL, { sessionId, projectPath, modelId }),
   fetchMarketplace: (forceRefresh) => ipcRenderer.invoke(IPC.MARKETPLACE_FETCH, { forceRefresh }),
   listInstalledPlugins: () => ipcRenderer.invoke(IPC.MARKETPLACE_INSTALLED),
   installPlugin: (repo, pluginName, marketplace, sourcePath, isSkillMd) =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,22 +39,7 @@ export default function App() {
   }, [setSystemTheme])
 
   useEffect(() => {
-    useSessionStore.getState().initStaticInfo().then(() => {
-      const homeDir = useSessionStore.getState().staticInfo?.homePath || '~'
-      const tab = useSessionStore.getState().tabs[0]
-      if (tab) {
-        // Set working directory to home by default (user hasn't chosen yet)
-        useSessionStore.setState((s) => ({
-          tabs: s.tabs.map((t, i) => (i === 0 ? { ...t, workingDirectory: homeDir, hasChosenDirectory: false } : t)),
-        }))
-        window.clui.createTab().then(({ tabId }) => {
-          useSessionStore.setState((s) => ({
-            tabs: s.tabs.map((t, i) => (i === 0 ? { ...t, id: tabId } : t)),
-            activeTabId: tabId,
-          }))
-        }).catch(() => {})
-      }
-    })
+    void useSessionStore.getState().initAndRestoreTabs()
   }, [])
 
   // Shared drag ref — must be declared before the setIgnoreMouseEvents effect so both closures can read it
@@ -312,7 +297,7 @@ export default function App() {
               <div className="btn-stack">
                 {/* btn-1: Attach (front, rightmost) */}
                 <button
-                  className="stack-btn stack-btn-1 glass-surface"
+                  className="stack-btn stack-btn-1 glass-surface clui-pointer"
                   title="Attach file"
                   onClick={handleAttachFile}
                   disabled={isRunning}
@@ -321,7 +306,7 @@ export default function App() {
                 </button>
                 {/* btn-2: Screenshot (middle) */}
                 <button
-                  className="stack-btn stack-btn-2 glass-surface"
+                  className="stack-btn stack-btn-2 glass-surface clui-pointer"
                   title="Take screenshot"
                   onClick={handleScreenshot}
                   disabled={isRunning}
@@ -330,7 +315,7 @@ export default function App() {
                 </button>
                 {/* btn-3: Skills (back, leftmost) */}
                 <button
-                  className="stack-btn stack-btn-3 glass-surface"
+                  className="stack-btn stack-btn-3 glass-surface clui-pointer"
                   title="Skills & Plugins"
                   onClick={() => useSessionStore.getState().toggleMarketplace()}
                   disabled={isRunning}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -58,7 +58,8 @@ export default function App() {
   }, [])
 
   // Shared drag ref — must be declared before the setIgnoreMouseEvents effect so both closures can read it
-  const dragRef = useRef<{ startX: number; startY: number } | null>(null)
+  const dragRef = useRef<{ startX: number; startY: number; active: boolean } | null>(null)
+  const DRAG_THRESHOLD_PX = 5
 
   // Vertical position tracking — window moves first (until macOS clamps it), then CSS overflows
   const PILL_HEIGHT_CONST = 720
@@ -75,7 +76,7 @@ export default function App() {
 
     const onMouseMove = (e: MouseEvent) => {
       // While dragging, keep full mouse capture — don't toggle ignore-events
-      if (dragRef.current) return
+      if (dragRef.current?.active) return
       const el = document.elementFromPoint(e.clientX, e.clientY)
       const isUI = !!(el && el.closest('[data-clui-ui]'))
       const shouldIgnore = !isUI
@@ -90,7 +91,7 @@ export default function App() {
     }
 
     const onMouseLeave = () => {
-      if (dragRef.current) return
+      if (dragRef.current?.active) return
       if (lastIgnored !== true) {
         lastIgnored = true
         window.clui.setIgnoreMouseEvents(true, { forward: true })
@@ -111,10 +112,9 @@ export default function App() {
 
     const onMouseDown = (e: MouseEvent) => {
       const el = e.target as HTMLElement
-      // Skip interactive elements — everything else on the card is draggable
-      if (el.closest('button, input, textarea, a, select, [role="button"], [contenteditable], .cm-editor')) return
+      // Skip interactive elements and chat body; tab strip + card chrome stay draggable
+      if (el.closest('button, input, textarea, a, select, [role="button"], [contenteditable], .cm-editor, .no-drag, .conversation-selectable, .prose-cloud')) return
       if (!el.closest('[data-clui-ui]')) return
-      e.preventDefault()
       // Double-click: snap back to default position
       if (e.detail >= 2) {
         window.clui.resetWindowPosition()
@@ -123,13 +123,18 @@ export default function App() {
         document.documentElement.style.setProperty('--clui-card-y', '0px')
         return
       }
-      // Ensure full mouse capture for the duration of the drag
-      window.clui.setIgnoreMouseEvents(false)
-      dragRef.current = { startX: e.screenX, startY: e.screenY }
+      dragRef.current = { startX: e.screenX, startY: e.screenY, active: false }
     }
 
     const onMouseMove = (e: MouseEvent) => {
       if (!dragRef.current) return
+      if (!dragRef.current.active) {
+        const pendingDx = e.screenX - dragRef.current.startX
+        const pendingDy = e.screenY - dragRef.current.startY
+        if (Math.hypot(pendingDx, pendingDy) < DRAG_THRESHOLD_PX) return
+        dragRef.current.active = true
+        window.clui.setIgnoreMouseEvents(false)
+      }
       const dx = e.screenX - dragRef.current.startX
       const dy = e.screenY - dragRef.current.startY
       if (dx !== 0 || dy !== 0) {
@@ -274,8 +279,8 @@ export default function App() {
               zIndex: isExpanded ? 20 : 10,
             }}
           >
-            {/* Tab strip — always mounted */}
-            <div className="no-drag">
+            {/* Tab strip — drag handle for the frameless window */}
+            <div>
               <TabStrip />
             </div>
 

--- a/src/renderer/components/HistoryPicker.tsx
+++ b/src/renderer/components/HistoryPicker.tsx
@@ -108,7 +108,7 @@ export function HistoryPicker() {
       <button
         ref={triggerRef}
         onClick={handleToggle}
-        className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
+        className="clui-pointer flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
         style={{ color: colors.textTertiary }}
         title="Resume a previous session"
       >

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Microphone, ArrowUp, SpinnerGap, X, Check } from '@phosphor-icons/react'
-import { useSessionStore, AVAILABLE_MODELS } from '../stores/sessionStore'
+import { useSessionStore, AVAILABLE_MODELS, getEffectiveModel, getModelDisplayLabel } from '../stores/sessionStore'
+import { useThemeStore } from '../theme'
 import { AttachmentChips } from './AttachmentChips'
 import { SlashCommandMenu, getFilteredCommandsWithExtras, type SlashCommand } from './SlashCommandMenu'
 import { useColors } from '../theme'
@@ -37,9 +38,9 @@ export function InputBar() {
   const addAttachments = useSessionStore((s) => s.addAttachments)
   const removeAttachment = useSessionStore((s) => s.removeAttachment)
 
-  const setPreferredModel = useSessionStore((s) => s.setPreferredModel)
+  const setTabModel = useSessionStore((s) => s.setTabModel)
   const staticInfo = useSessionStore((s) => s.staticInfo)
-  const preferredModel = useSessionStore((s) => s.preferredModel)
+  const defaultModel = useThemeStore((s) => s.defaultModel)
   const activeTabId = useSessionStore((s) => s.activeTabId)
   const tab = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId))
   const colors = useColors()
@@ -178,15 +179,15 @@ export function InputBar() {
         break
       }
       case '/model': {
-        const model = tab?.sessionModel || null
         const version = tab?.sessionVersion || staticInfo?.version || null
-        const current = preferredModel || model || 'default'
+        const current = tab ? getEffectiveModel(tab, defaultModel) : defaultModel
+        const scope = tab?.modelOverride ? 'this session' : 'default (settings)'
         const lines = AVAILABLE_MODELS.map((m) => {
-          const active = m.id === current || (!preferredModel && m.id === model)
+          const active = m.id === current
           return `  ${active ? '\u25CF' : '\u25CB'} ${m.label} (${m.id})`
         })
         const header = version ? `Claude Code ${version}` : 'Claude Code'
-        addSystemMessage(`${header}\n\n${lines.join('\n')}\n\nSwitch model: type /model <name>\n  e.g. /model sonnet`)
+        addSystemMessage(`${header}\n\nActive: ${getModelDisplayLabel(current)} (${scope})\n\n${lines.join('\n')}\n\nSwitch model for this session: /model <name>\n  e.g. /model sonnet`)
         break
       }
       case '/mcp': {
@@ -227,7 +228,7 @@ export function InputBar() {
         break
       }
     }
-  }, [tab, clearTab, addSystemMessage, staticInfo, preferredModel])
+  }, [tab, clearTab, addSystemMessage, staticInfo, defaultModel])
 
   const handleSlashSelect = useCallback((cmd: SlashCommand) => {
     const isSkillCommand = !!tab?.sessionSkills?.includes(cmd.command.replace(/^\//, ''))
@@ -259,7 +260,7 @@ export function InputBar() {
         m.id.toLowerCase().includes(query) || m.label.toLowerCase().includes(query)
       )
       if (match) {
-        setPreferredModel(match.id)
+        setTabModel(match.id)
         setInput('')
         setSlashFilter(null)
         addSystemMessage(`Model switched to ${match.label} (${match.id})`)

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -401,7 +401,7 @@ export function InputBar() {
       {/* Single-line: inline controls. Multi-line: controls in bottom row */}
       <div className="w-full" style={{ minHeight: 50 }}>
         {isMultiLine ? (
-          <div className="w-full">
+          <div className="clui-text-input w-full">
             <textarea
               ref={textareaRef}
               value={input}
@@ -459,7 +459,7 @@ export function InputBar() {
             </div>
           </div>
         ) : (
-          <div className="flex items-center w-full" style={{ minHeight: 50 }}>
+          <div className="clui-text-input flex items-center w-full" style={{ minHeight: 50 }}>
             <textarea
               ref={textareaRef}
               value={input}
@@ -585,7 +585,7 @@ function VoiceButtons({ voiceState, isConnecting, colors, onToggle, onCancel, on
             onMouseDown={(e) => e.preventDefault()}
             onClick={onToggle}
             disabled={isConnecting}
-            className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
+            className="clui-pointer w-9 h-9 rounded-full flex items-center justify-center transition-colors"
             style={{
               background: colors.micBg,
               color: isConnecting ? colors.micDisabled : colors.micColor,

--- a/src/renderer/components/PermissionDeniedCard.tsx
+++ b/src/renderer/components/PermissionDeniedCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 import { ShieldWarning, Terminal, ArrowSquareOut } from '@phosphor-icons/react'
-import { useColors } from '../theme'
+import { useColors, useThemeStore } from '../theme'
 
 interface Props {
   tools: Array<{ toolName: string; toolUseId: string }>
@@ -12,10 +12,11 @@ interface Props {
 
 export function PermissionDeniedCard({ tools, sessionId, projectPath, onDismiss }: Props) {
   const colors = useColors()
+  const cliTerminal = useThemeStore((s) => s.cliTerminal)
 
   const handleOpenInCli = () => {
     if (sessionId) {
-      window.clui.openInTerminal(sessionId, projectPath)
+      window.clui.openInTerminal(sessionId, projectPath, cliTerminal)
     }
     onDismiss()
   }

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { DotsThree, Bell, ArrowsOutSimple, Moon } from '@phosphor-icons/react'
+import { DotsThree, Bell, ArrowsOutSimple, Moon, Robot, CaretDown, Check } from '@phosphor-icons/react'
 import { useThemeStore } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
+import { AVAILABLE_MODELS, getModelDisplayLabel } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
 
@@ -50,7 +51,10 @@ export function SettingsPopover() {
   const setThemeMode = useThemeStore((s) => s.setThemeMode)
   const expandedUI = useThemeStore((s) => s.expandedUI)
   const setExpandedUI = useThemeStore((s) => s.setExpandedUI)
+  const defaultModel = useThemeStore((s) => s.defaultModel)
+  const setDefaultModel = useThemeStore((s) => s.setDefaultModel)
   const isExpanded = useSessionStore((s) => s.isExpanded)
+  const [modelMenuOpen, setModelMenuOpen] = useState(false)
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
 
@@ -92,6 +96,7 @@ export function SettingsPopover() {
       const target = e.target as Node
       if (triggerRef.current?.contains(target)) return
       if (popoverRef.current?.contains(target)) return
+      setModelMenuOpen(false)
       setOpen(false)
     }
     document.addEventListener('mousedown', handler)
@@ -220,6 +225,63 @@ export function SettingsPopover() {
                   label="Toggle dark theme"
                 />
               </div>
+            </div>
+
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            {/* Default model */}
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Robot size={14} style={{ color: colors.textTertiary }} />
+                  <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                    Default model
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setModelMenuOpen((o) => !o)}
+                  className="flex items-center gap-0.5 text-[11px] rounded-full px-2 py-0.5 transition-colors"
+                  style={{ color: colors.textSecondary, border: `1px solid ${colors.containerBorder}` }}
+                  aria-expanded={modelMenuOpen}
+                  aria-haspopup="listbox"
+                >
+                  {getModelDisplayLabel(defaultModel)}
+                  <CaretDown size={10} style={{ opacity: 0.6 }} />
+                </button>
+              </div>
+              {modelMenuOpen && (
+                <div
+                  className="mt-2 rounded-lg overflow-hidden"
+                  style={{ border: `1px solid ${colors.popoverBorder}` }}
+                  role="listbox"
+                >
+                  {AVAILABLE_MODELS.map((m) => {
+                    const isSelected = defaultModel === m.id
+                    return (
+                      <button
+                        key={m.id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => {
+                          setDefaultModel(m.id)
+                          setModelMenuOpen(false)
+                        }}
+                        className="w-full flex items-center justify-between px-2.5 py-1.5 text-[11px] transition-colors"
+                        style={{
+                          color: isSelected ? colors.textPrimary : colors.textSecondary,
+                          fontWeight: isSelected ? 600 : 400,
+                          background: isSelected ? colors.surfaceSecondary : 'transparent',
+                        }}
+                      >
+                        {m.label}
+                        {isSelected && <Check size={12} style={{ color: colors.accent }} />}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
             </div>
           </div>
         </motion.div>,

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { DotsThree, Bell, ArrowsOutSimple, Moon, Robot, CaretDown, Check } from '@phosphor-icons/react'
-import { useThemeStore } from '../theme'
+import { DotsThree, Bell, ArrowsOutSimple, Moon, Robot, Terminal, CaretDown, Check } from '@phosphor-icons/react'
+import { useThemeStore, CLI_TERMINAL_OPTIONS } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import { AVAILABLE_MODELS, getModelDisplayLabel } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
@@ -53,8 +53,11 @@ export function SettingsPopover() {
   const setExpandedUI = useThemeStore((s) => s.setExpandedUI)
   const defaultModel = useThemeStore((s) => s.defaultModel)
   const setDefaultModel = useThemeStore((s) => s.setDefaultModel)
+  const cliTerminal = useThemeStore((s) => s.cliTerminal)
+  const setCliTerminal = useThemeStore((s) => s.setCliTerminal)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const [modelMenuOpen, setModelMenuOpen] = useState(false)
+  const [cliMenuOpen, setCliMenuOpen] = useState(false)
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
 
@@ -97,6 +100,7 @@ export function SettingsPopover() {
       if (triggerRef.current?.contains(target)) return
       if (popoverRef.current?.contains(target)) return
       setModelMenuOpen(false)
+      setCliMenuOpen(false)
       setOpen(false)
     }
     document.addEventListener('mousedown', handler)
@@ -276,6 +280,63 @@ export function SettingsPopover() {
                         }}
                       >
                         {m.label}
+                        {isSelected && <Check size={12} style={{ color: colors.accent }} />}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            {/* Open in CLI app */}
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <Terminal size={14} style={{ color: colors.textTertiary }} />
+                  <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                    Open in CLI
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setCliMenuOpen((o) => !o)}
+                  className="flex items-center gap-0.5 text-[11px] rounded-full px-2 py-0.5 transition-colors"
+                  style={{ color: colors.textSecondary, border: `1px solid ${colors.containerBorder}` }}
+                  aria-expanded={cliMenuOpen}
+                  aria-haspopup="listbox"
+                >
+                  {CLI_TERMINAL_OPTIONS.find((o) => o.id === cliTerminal)?.label ?? 'Terminal'}
+                  <CaretDown size={10} style={{ opacity: 0.6 }} />
+                </button>
+              </div>
+              {cliMenuOpen && (
+                <div
+                  className="mt-2 rounded-lg overflow-hidden"
+                  style={{ border: `1px solid ${colors.popoverBorder}` }}
+                  role="listbox"
+                >
+                  {CLI_TERMINAL_OPTIONS.map((o) => {
+                    const isSelected = cliTerminal === o.id
+                    return (
+                      <button
+                        key={o.id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => {
+                          setCliTerminal(o.id)
+                          setCliMenuOpen(false)
+                        }}
+                        className="w-full flex items-center justify-between px-2.5 py-1.5 text-[11px] transition-colors"
+                        style={{
+                          color: isSelected ? colors.textPrimary : colors.textSecondary,
+                          fontWeight: isSelected ? 600 : 400,
+                          background: isSelected ? colors.surfaceSecondary : 'transparent',
+                        }}
+                      >
+                        {o.label}
                         {isSelected && <Check size={12} style={{ color: colors.accent }} />}
                       </button>
                     )

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -139,7 +139,7 @@ export function SettingsPopover() {
       <button
         ref={triggerRef}
         onClick={handleToggle}
-        className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
+        className="clui-pointer flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
         style={{ color: colors.textTertiary }}
         title="Settings"
       >

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -2,18 +2,19 @@ import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Terminal, CaretDown, Check, FolderOpen, Plus, X, ShieldCheck } from '@phosphor-icons/react'
-import { useSessionStore, AVAILABLE_MODELS, getModelDisplayLabel } from '../stores/sessionStore'
+import { useSessionStore, AVAILABLE_MODELS, getModelDisplayLabel, getEffectiveModel } from '../stores/sessionStore'
+import { useThemeStore } from '../theme'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
 
 /* ─── Model Picker (inline — tightly coupled to StatusBar) ─── */
 
 function ModelPicker() {
-  const preferredModel = useSessionStore((s) => s.preferredModel)
-  const setPreferredModel = useSessionStore((s) => s.setPreferredModel)
+  const defaultModel = useThemeStore((s) => s.defaultModel)
+  const setTabModel = useSessionStore((s) => s.setTabModel)
   const tab = useSessionStore(
     (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b && a.status === b.status && a.sessionModel === b.sessionModel),
+    (a, b) => a === b || (!!a && !!b && a.status === b.status && a.sessionModel === b.sessionModel && a.modelOverride === b.modelOverride),
   )
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
@@ -52,15 +53,10 @@ function ModelPicker() {
     setOpen((o) => !o)
   }
 
+  const effectiveModel = tab ? getEffectiveModel(tab, defaultModel) : defaultModel
   const activeLabel = (() => {
-    if (preferredModel) {
-      const m = AVAILABLE_MODELS.find((m) => m.id === preferredModel)
-      return m?.label || getModelDisplayLabel(preferredModel)
-    }
-    if (tab?.sessionModel) {
-      return getModelDisplayLabel(tab.sessionModel)
-    }
-    return AVAILABLE_MODELS[0].label
+    const m = AVAILABLE_MODELS.find((item) => item.id === effectiveModel)
+    return m?.label || getModelDisplayLabel(effectiveModel)
   })()
 
   return (
@@ -103,11 +99,11 @@ function ModelPicker() {
         >
           <div className="py-1">
             {AVAILABLE_MODELS.map((m) => {
-              const isSelected = preferredModel === m.id || (!preferredModel && m.id === AVAILABLE_MODELS[0].id)
+              const isSelected = effectiveModel === m.id
               return (
                 <button
                   key={m.id}
-                  onClick={() => { setPreferredModel(m.id); setOpen(false) }}
+                  onClick={() => { setTabModel(m.id); setOpen(false) }}
                   className="w-full flex items-center justify-between px-3 py-1.5 text-[11px] transition-colors"
                   style={{
                     color: isSelected ? colors.textPrimary : colors.textSecondary,

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -437,7 +437,7 @@ export function StatusBar() {
       <div className="flex items-center gap-1.5 flex-shrink-0">
         <button
           onClick={handleOpenInTerminal}
-          className="flex items-center gap-1 text-[11px] rounded-full px-2 py-0.5 transition-colors"
+          className="clui-pointer flex items-center gap-1 text-[11px] rounded-full px-2 py-0.5 transition-colors"
           style={{ color: colors.textTertiary }}
           title={`Open this session in ${cliLabel}`}
         >

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -3,9 +3,8 @@ import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Terminal, CaretDown, Check, FolderOpen, Plus, X, ShieldCheck } from '@phosphor-icons/react'
 import { useSessionStore, AVAILABLE_MODELS, getModelDisplayLabel, getEffectiveModel } from '../stores/sessionStore'
-import { useThemeStore } from '../theme'
 import { usePopoverLayer } from './PopoverLayer'
-import { useColors } from '../theme'
+import { useColors, useThemeStore } from '../theme'
 
 /* ─── Model Picker (inline — tightly coupled to StatusBar) ─── */
 
@@ -292,8 +291,11 @@ export function StatusBar() {
   const isEmpty = tab.messages.length === 0
   const hasExtraDirs = tab.additionalDirs.length > 0
 
+  const cliTerminal = useThemeStore((s) => s.cliTerminal)
+  const cliLabel = cliTerminal === 'iterm' ? 'iTerm' : 'Terminal'
+
   const handleOpenInTerminal = () => {
-    window.clui.openInTerminal(tab.claudeSessionId, tab.workingDirectory)
+    window.clui.openInTerminal(tab.claudeSessionId, tab.workingDirectory, cliTerminal)
   }
 
   const handleDirClick = () => {
@@ -437,7 +439,7 @@ export function StatusBar() {
           onClick={handleOpenInTerminal}
           className="flex items-center gap-1 text-[11px] rounded-full px-2 py-0.5 transition-colors"
           style={{ color: colors.textTertiary }}
-          title="Open this session in Terminal"
+          title={`Open this session in ${cliLabel}`}
         >
           Open in CLI
           <Terminal size={11} />

--- a/src/renderer/components/TabStrip.tsx
+++ b/src/renderer/components/TabStrip.tsx
@@ -93,7 +93,7 @@ export function TabStrip() {
                   {tabs.length > 1 && (
                     <button
                       onClick={(e) => { e.stopPropagation(); closeTab(tab.id) }}
-                      className="flex-shrink-0 rounded-full w-4 h-4 flex items-center justify-center transition-opacity"
+                      className="clui-pointer flex-shrink-0 rounded-full w-4 h-4 flex items-center justify-center transition-opacity"
                       style={{
                         opacity: isActive ? 0.5 : 0,
                         color: colors.textSecondary,
@@ -115,7 +115,7 @@ export function TabStrip() {
       <div className="flex items-center gap-0.5 flex-shrink-0 ml-1 pr-2">
         <button
           onClick={() => createTab()}
-          className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
+          className="clui-pointer flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full transition-colors"
           style={{ color: colors.textTertiary }}
           title="New tab"
         >

--- a/src/renderer/components/TabStrip.tsx
+++ b/src/renderer/components/TabStrip.tsx
@@ -47,7 +47,7 @@ export function TabStrip() {
   return (
     <div
       data-clui-ui
-      className="flex items-center no-drag"
+      className="flex items-center"
       style={{ padding: '8px 0' }}
     >
       {/* Scrollable tabs area — clipped by master card edge */}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -54,9 +54,19 @@ input::placeholder {
 
 /* ─── Allow text selection in conversation content ─── */
 .prose-cloud,
-.conversation-selectable {
+.conversation-selectable,
+.no-drag .prose-cloud,
+.no-drag .conversation-selectable {
   user-select: text;
   -webkit-user-select: text;
+  cursor: text;
+}
+.conversation-selectable button,
+.conversation-selectable a,
+.conversation-selectable [role="button"],
+.conversation-selectable .cursor-pointer,
+.prose-cloud a {
+  cursor: pointer;
 }
 
 /* ─── Prose overrides for markdown ─── */

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -47,6 +47,20 @@ textarea {
 textarea:focus {
   outline: none;
 }
+
+/* ─── Cursor hints for interactive chrome ─── */
+.clui-pointer {
+  cursor: pointer;
+}
+.clui-pointer:disabled {
+  cursor: not-allowed;
+}
+.clui-text-input,
+.clui-text-input textarea {
+  cursor: text;
+  user-select: text;
+  -webkit-user-select: text;
+}
 textarea::placeholder,
 input::placeholder {
   color: var(--clui-placeholder);

--- a/src/renderer/models.ts
+++ b/src/renderer/models.ts
@@ -1,0 +1,53 @@
+/** Known Claude models available in the UI picker */
+export const AVAILABLE_MODELS = [
+  { id: 'claude-opus-4-6', label: 'Opus 4.6' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+] as const
+
+export const DEFAULT_MODEL_ID = AVAILABLE_MODELS[0].id
+
+export type ModelId = (typeof AVAILABLE_MODELS)[number]['id']
+
+function normalizeModelId(modelId: string): string {
+  return modelId.replace(/\[[^\]]+\]/g, '').trim()
+}
+
+export function isKnownModelId(modelId: string): boolean {
+  const normalized = normalizeModelId(modelId)
+  return AVAILABLE_MODELS.some((m) => m.id === normalized)
+}
+
+export function resolveModelId(modelId: string | null | undefined): string {
+  if (modelId && isKnownModelId(modelId)) return normalizeModelId(modelId)
+  return DEFAULT_MODEL_ID
+}
+
+export function getModelDisplayLabel(modelId: string): string {
+  const normalizedId = normalizeModelId(modelId)
+  const has1MContext = /\[\s*1m\s*\]/i.test(modelId)
+
+  const known = AVAILABLE_MODELS.find((m) => m.id === normalizedId)
+  if (known) {
+    return has1MContext ? `${known.label} (1M)` : known.label
+  }
+
+  const compact = normalizedId
+    .replace(/^claude-/, '')
+    .replace(/-\d{8}$/, '')
+  const familyMatch = compact.match(/^(opus|sonnet|haiku)-(\d+)-(\d+)$/i)
+  if (familyMatch) {
+    const family = familyMatch[1][0].toUpperCase() + familyMatch[1].slice(1).toLowerCase()
+    const label = `${family} ${familyMatch[2]}.${familyMatch[3]}`
+    return has1MContext ? `${label} (1M)` : label
+  }
+
+  return has1MContext ? `${normalizedId} (1M)` : normalizedId
+}
+
+export function getEffectiveModel(
+  tab: { modelOverride: string | null },
+  defaultModel: string,
+): string {
+  return tab.modelOverride ?? resolveModelId(defaultModel)
+}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -1,42 +1,33 @@
 import { create } from 'zustand'
 import type { TabStatus, NormalizedEvent, EnrichedError, Message, TabState, Attachment, CatalogPlugin, PluginStatus } from '../../shared/types'
 import { useThemeStore } from '../theme'
+import {
+  AVAILABLE_MODELS,
+  getEffectiveModel,
+  getModelDisplayLabel,
+  isKnownModelId,
+} from '../models'
 import notificationSrc from '../../../resources/notification.mp3'
 
-// ─── Known models ───
+export { AVAILABLE_MODELS, getModelDisplayLabel, getEffectiveModel }
 
-export const AVAILABLE_MODELS = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-] as const
-
-function normalizeModelId(modelId: string): string {
-  // Claude sometimes appends context window hints like "[1m]" to model IDs.
-  return modelId.replace(/\[[^\]]+\]/g, '').trim()
+function resolveProjectPath(tab: TabState, homePath?: string): string {
+  if (tab.workingDirectory && tab.workingDirectory !== '~') return tab.workingDirectory
+  return homePath || '~'
 }
 
-export function getModelDisplayLabel(modelId: string): string {
-  const normalizedId = normalizeModelId(modelId)
-  const has1MContext = /\[\s*1m\s*\]/i.test(modelId)
+async function persistSessionModel(tab: TabState, homePath?: string): Promise<void> {
+  if (!tab.claudeSessionId || !tab.modelOverride) return
+  const projectPath = resolveProjectPath(tab, homePath)
+  await window.clui.setSessionModel(tab.claudeSessionId, projectPath, tab.modelOverride).catch(() => {})
+}
 
-  const known = AVAILABLE_MODELS.find((m) => m.id === normalizedId)
-  if (known) {
-    return has1MContext ? `${known.label} (1M)` : known.label
-  }
-
-  // Fallback for future model IDs not yet listed in AVAILABLE_MODELS.
-  const compact = normalizedId
-    .replace(/^claude-/, '')
-    .replace(/-\d{8}$/, '')
-  const familyMatch = compact.match(/^(opus|sonnet|haiku)-(\d+)-(\d+)$/i)
-  if (familyMatch) {
-    const family = familyMatch[1][0].toUpperCase() + familyMatch[1].slice(1).toLowerCase()
-    const label = `${family} ${familyMatch[2]}.${familyMatch[3]}`
-    return has1MContext ? `${label} (1M)` : label
-  }
-
-  return has1MContext ? `${normalizedId} (1M)` : normalizedId
+async function loadSessionModelOverride(
+  sessionId: string,
+  projectPath: string,
+): Promise<string | null> {
+  const saved = await window.clui.getSessionModel(sessionId, projectPath).catch(() => null)
+  return saved && isKnownModelId(saved) ? saved : null
 }
 
 // ─── Store ───
@@ -56,8 +47,6 @@ interface State {
   isExpanded: boolean
   /** Global info fetched on startup (not per-session) */
   staticInfo: StaticInfo | null
-  /** User's preferred model override (null = use default) */
-  preferredModel: string | null
   /** Global permission mode: 'ask' shows cards, 'auto' auto-approves all tool calls */
   permissionMode: 'ask' | 'auto'
 
@@ -73,7 +62,7 @@ interface State {
 
   // Actions
   initStaticInfo: () => Promise<void>
-  setPreferredModel: (model: string | null) => void
+  setTabModel: (modelId: string) => void
   setPermissionMode: (mode: 'ask' | 'auto') => void
   createTab: () => Promise<string>
   selectTab: (tabId: string) => void
@@ -136,6 +125,7 @@ function makeLocalTab(): TabState {
     title: 'New Tab',
     lastResult: null,
     sessionModel: null,
+    modelOverride: null,
     sessionTools: [],
     sessionMcpServers: [],
     sessionSkills: [],
@@ -154,7 +144,6 @@ export const useSessionStore = create<State>((set, get) => ({
   activeTabId: initialTab.id,
   isExpanded: false,
   staticInfo: null,
-  preferredModel: null,
   permissionMode: 'ask',
 
   // Marketplace
@@ -182,8 +171,18 @@ export const useSessionStore = create<State>((set, get) => ({
     } catch {}
   },
 
-  setPreferredModel: (model) => {
-    set({ preferredModel: model })
+  setTabModel: (modelId) => {
+    if (!isKnownModelId(modelId)) return
+    const { activeTabId, staticInfo } = get()
+    let updatedTab: TabState | null = null
+    set((s) => ({
+      tabs: s.tabs.map((t) => {
+        if (t.id !== activeTabId) return t
+        updatedTab = { ...t, modelOverride: modelId }
+        return updatedTab
+      }),
+    }))
+    if (updatedTab) void persistSessionModel(updatedTab, staticInfo?.homePath)
   },
 
   setPermissionMode: (mode) => {
@@ -394,6 +393,7 @@ export const useSessionStore = create<State>((set, get) => ({
         timestamp: m.timestamp,
       }))
 
+      const savedModel = await loadSessionModelOverride(sessionId, defaultDir)
       const tab: TabState = {
         ...makeLocalTab(),
         id: tabId,
@@ -402,6 +402,7 @@ export const useSessionStore = create<State>((set, get) => ({
         workingDirectory: defaultDir,
         hasChosenDirectory: !!projectPath,
         messages,
+        modelOverride: savedModel,
       }
       set((s) => ({
         tabs: [...s.tabs, tab],
@@ -411,11 +412,13 @@ export const useSessionStore = create<State>((set, get) => ({
       // Don't call initSession — the first real prompt will use --resume with the sessionId
       return tabId
     } catch {
+      const savedModel = await loadSessionModelOverride(sessionId, defaultDir).catch(() => null)
       const tab = makeLocalTab()
       tab.claudeSessionId = sessionId
       tab.title = title || 'Resumed Session'
       tab.workingDirectory = defaultDir
       tab.hasChosenDirectory = !!projectPath
+      tab.modelOverride = savedModel
       set((s) => ({
         tabs: [...s.tabs, tab],
         activeTabId: tab.id,
@@ -504,6 +507,7 @@ export const useSessionStore = create<State>((set, get) => ({
               workingDirectory: dir,
               hasChosenDirectory: true,
               claudeSessionId: null,
+              modelOverride: null,
               additionalDirs: [],
             }
           : t
@@ -610,12 +614,13 @@ export const useSessionStore = create<State>((set, get) => ({
     }))
 
     // Send to backend — ControlPlane will queue if a run is active
-    const { preferredModel } = get()
+    const defaultModel = useThemeStore.getState().defaultModel
+    const model = getEffectiveModel(tab, defaultModel)
     window.clui.prompt(activeTabId, requestId, {
       prompt: fullPrompt,
       projectPath: resolvedPath,
       sessionId: tab.claudeSessionId || undefined,
-      model: preferredModel || undefined,
+      model,
       addDirs: tab.additionalDirs.length > 0 ? tab.additionalDirs : undefined,
     }).catch((err: Error) => {
       get().handleError(activeTabId, {
@@ -638,13 +643,27 @@ export const useSessionStore = create<State>((set, get) => ({
         const updated = { ...tab }
 
         switch (event.type) {
-          case 'session_init':
+          case 'session_init': {
             updated.claudeSessionId = event.sessionId
             updated.sessionModel = event.model
             updated.sessionTools = event.tools
             updated.sessionMcpServers = event.mcpServers
             updated.sessionSkills = event.skills
             updated.sessionVersion = event.version
+            const tabSnapshot = { ...updated }
+            if (updated.modelOverride) {
+              void persistSessionModel(tabSnapshot, s.staticInfo?.homePath)
+            } else {
+              void loadSessionModelOverride(event.sessionId, resolveProjectPath(tabSnapshot, s.staticInfo?.homePath))
+                .then((savedModel) => {
+                  if (!savedModel) return
+                  useSessionStore.setState((state) => ({
+                    tabs: state.tabs.map((t) =>
+                      t.id === tabId && !t.modelOverride ? { ...t, modelOverride: savedModel } : t,
+                    ),
+                  }))
+                })
+            }
             // Don't change status/activity for warmup inits — they're invisible
             if (!event.isWarmup) {
               updated.status = 'running'
@@ -660,6 +679,7 @@ export const useSessionStore = create<State>((set, get) => ({
               }
             }
             break
+          }
 
           case 'text_chunk': {
             updated.currentActivity = 'Writing...'

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -8,6 +8,7 @@ import {
   isKnownModelId,
 } from '../models'
 import notificationSrc from '../../../resources/notification.mp3'
+import { loadOpenTabs, loadTabHistory, saveOpenTabs, type PersistedTabSnapshot } from '../tab-persistence'
 
 export { AVAILABLE_MODELS, getModelDisplayLabel, getEffectiveModel }
 
@@ -62,6 +63,8 @@ interface State {
 
   // Actions
   initStaticInfo: () => Promise<void>
+  /** Load static info, restore open tabs from last session, or create one default tab */
+  initAndRestoreTabs: () => Promise<void>
   setTabModel: (modelId: string) => void
   setPermissionMode: (mode: 'ask' | 'auto') => void
   createTab: () => Promise<string>
@@ -108,6 +111,40 @@ async function playNotificationIfHidden(): Promise<void> {
       notificationAudio.play().catch(() => {})
     }
   } catch {}
+}
+
+let tabPersistenceEnabled = false
+
+async function buildTabFromSnapshot(
+  homeDir: string,
+  snapshot?: PersistedTabSnapshot,
+): Promise<TabState> {
+  const { tabId } = await window.clui.createTab()
+  const projectPath =
+    !snapshot?.workingDirectory || snapshot.workingDirectory === '~'
+      ? homeDir
+      : snapshot.workingDirectory
+
+  let messages: Message[] = []
+  let modelOverride = snapshot?.modelOverride ?? null
+  if (snapshot?.claudeSessionId) {
+    messages = await loadTabHistory(snapshot.claudeSessionId, projectPath)
+    if (!modelOverride) {
+      modelOverride = await loadSessionModelOverride(snapshot.claudeSessionId, projectPath)
+    }
+  }
+
+  return {
+    ...makeLocalTab(),
+    id: tabId,
+    title: snapshot?.title ?? 'New Tab',
+    claudeSessionId: snapshot?.claudeSessionId ?? null,
+    workingDirectory: snapshot?.workingDirectory ?? homeDir,
+    hasChosenDirectory: snapshot?.hasChosenDirectory ?? false,
+    additionalDirs: snapshot?.additionalDirs ?? [],
+    modelOverride,
+    messages,
+  }
 }
 
 function makeLocalTab(): TabState {
@@ -169,6 +206,42 @@ export const useSessionStore = create<State>((set, get) => ({
         },
       })
     } catch {}
+  },
+
+  initAndRestoreTabs: async () => {
+    tabPersistenceEnabled = false
+    await get().initStaticInfo()
+    const homeDir = get().staticInfo?.homePath || '~'
+
+    try {
+      const saved = loadOpenTabs()
+      if (saved?.tabs.length) {
+        const restored: TabState[] = []
+        for (const snap of saved.tabs) {
+          restored.push(await buildTabFromSnapshot(homeDir, snap))
+        }
+        const active = restored[Math.min(saved.activeTabIndex, restored.length - 1)]
+        set({ tabs: restored, activeTabId: active.id })
+      } else {
+        const tab = await buildTabFromSnapshot(homeDir)
+        set({ tabs: [tab], activeTabId: tab.id })
+      }
+    } catch {
+      const fallback = makeLocalTab()
+      fallback.workingDirectory = homeDir
+      set({ tabs: [fallback], activeTabId: fallback.id })
+      try {
+        const { tabId } = await window.clui.createTab()
+        set((s) => ({
+          tabs: s.tabs.map((t) => (t.id === fallback.id ? { ...t, id: tabId } : t)),
+          activeTabId: tabId,
+        }))
+      } catch {}
+    }
+
+    tabPersistenceEnabled = true
+    const { tabs, activeTabId } = get()
+    if (tabs.length > 0) saveOpenTabs(tabs, activeTabId)
   },
 
   setTabModel: (modelId) => {
@@ -354,8 +427,7 @@ export const useSessionStore = create<State>((set, get) => ({
 
     if (s.activeTabId === tabId) {
       if (remaining.length === 0) {
-        const newTab = makeLocalTab()
-        set({ tabs: [newTab], activeTabId: newTab.id })
+        void get().createTab()
         return
       }
       const closedIndex = s.tabs.findIndex((t) => t.id === tabId)
@@ -952,3 +1024,10 @@ export const useSessionStore = create<State>((set, get) => ({
     }))
   },
 }))
+
+// Persist open tabs on every change; closed tabs are omitted automatically.
+useSessionStore.subscribe((state) => {
+  if (!tabPersistenceEnabled) return
+  if (state.tabs.length === 0) return
+  saveOpenTabs(state.tabs, state.activeTabId)
+})

--- a/src/renderer/tab-persistence.ts
+++ b/src/renderer/tab-persistence.ts
@@ -1,0 +1,100 @@
+import type { Message, TabState } from '../shared/types'
+import { isKnownModelId } from './models'
+
+const TABS_STORAGE_KEY = 'clui-open-tabs'
+const MAX_PERSISTED_TABS = 20
+
+const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export interface PersistedTabSnapshot {
+  title: string
+  claudeSessionId: string | null
+  workingDirectory: string
+  hasChosenDirectory: boolean
+  additionalDirs: string[]
+  modelOverride: string | null
+}
+
+export interface PersistedTabsState {
+  tabs: PersistedTabSnapshot[]
+  activeTabIndex: number
+}
+
+export function tabToSnapshot(tab: TabState): PersistedTabSnapshot {
+  return {
+    title: tab.title || 'New Tab',
+    claudeSessionId:
+      tab.claudeSessionId && SESSION_UUID_RE.test(tab.claudeSessionId)
+        ? tab.claudeSessionId
+        : null,
+    workingDirectory: tab.workingDirectory || '~',
+    hasChosenDirectory: tab.hasChosenDirectory,
+    additionalDirs: [...tab.additionalDirs],
+    modelOverride: tab.modelOverride && isKnownModelId(tab.modelOverride) ? tab.modelOverride : null,
+  }
+}
+
+export function saveOpenTabs(tabs: TabState[], activeTabId: string): void {
+  if (tabs.length === 0) return
+  const activeIndex = tabs.findIndex((t) => t.id === activeTabId)
+  const payload: PersistedTabsState = {
+    tabs: tabs.slice(0, MAX_PERSISTED_TABS).map(tabToSnapshot),
+    activeTabIndex: activeIndex >= 0 ? activeIndex : 0,
+  }
+  try {
+    localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(payload))
+  } catch {}
+}
+
+export function loadOpenTabs(): PersistedTabsState | null {
+  try {
+    const raw = localStorage.getItem(TABS_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as PersistedTabsState
+    if (!parsed || !Array.isArray(parsed.tabs) || parsed.tabs.length === 0) return null
+    const tabs = parsed.tabs.slice(0, MAX_PERSISTED_TABS).map((t) => ({
+      title: typeof t.title === 'string' && t.title.trim() ? t.title : 'New Tab',
+      claudeSessionId:
+        typeof t.claudeSessionId === 'string' && SESSION_UUID_RE.test(t.claudeSessionId)
+          ? t.claudeSessionId
+          : null,
+      workingDirectory: typeof t.workingDirectory === 'string' ? t.workingDirectory : '~',
+      hasChosenDirectory: !!t.hasChosenDirectory,
+      additionalDirs: Array.isArray(t.additionalDirs)
+        ? t.additionalDirs.filter((d): d is string => typeof d === 'string')
+        : [],
+      modelOverride:
+        typeof t.modelOverride === 'string' && isKnownModelId(t.modelOverride)
+          ? t.modelOverride
+          : null,
+    }))
+    const activeTabIndex =
+      typeof parsed.activeTabIndex === 'number' && parsed.activeTabIndex >= 0
+        ? Math.min(parsed.activeTabIndex, tabs.length - 1)
+        : 0
+    return { tabs, activeTabIndex }
+  } catch {
+    return null
+  }
+}
+
+export function clearPersistedTabs(): void {
+  try {
+    localStorage.removeItem(TABS_STORAGE_KEY)
+  } catch {}
+}
+
+export async function loadTabHistory(
+  sessionId: string,
+  projectPath: string,
+): Promise<Message[]> {
+  const history = await window.clui.loadSession(sessionId, projectPath).catch(() => [])
+  return history.map((m) => ({
+    id: `restored-${sessionId}-${m.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+    role: m.role as Message['role'],
+    content: m.content,
+    toolName: m.toolName,
+    toolStatus: m.toolName ? ('completed' as const) : undefined,
+    timestamp: m.timestamp,
+  }))
+}

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -335,8 +335,7 @@ function saveSettings(s: { themeMode: ThemeMode; soundEnabled: boolean; expanded
   try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(s)) } catch {}
 }
 
-// Always start in compact UI mode on launch.
-const saved = { ...loadSettings(), expandedUI: false }
+const saved = loadSettings()
 
 export const useThemeStore = create<ThemeState>((set, get) => ({
   isDark: saved.themeMode === 'dark' ? true : saved.themeMode === 'light' ? false : true,

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -3,6 +3,7 @@
  * Colors derived from ChatCN oklch system and design-fixed.html reference.
  */
 import { create } from 'zustand'
+import { DEFAULT_MODEL_ID, isKnownModelId } from './models'
 
 // ─── Color palettes ───
 
@@ -285,12 +286,15 @@ interface ThemeState {
   themeMode: ThemeMode
   soundEnabled: boolean
   expandedUI: boolean
+  /** Global default model for new sessions (per-session overrides live on TabState) */
+  defaultModel: string
   /** OS-reported dark mode — used when themeMode is 'system' */
   _systemIsDark: boolean
   setIsDark: (isDark: boolean) => void
   setThemeMode: (mode: ThemeMode) => void
   setSoundEnabled: (enabled: boolean) => void
   setExpandedUI: (expanded: boolean) => void
+  setDefaultModel: (modelId: string) => void
   /** Called by OS theme change listener — updates system value */
   setSystemTheme: (isDark: boolean) => void
 }
@@ -316,7 +320,14 @@ function applyTheme(isDark: boolean): void {
 
 const SETTINGS_KEY = 'clui-settings'
 
-function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean } {
+type PersistedSettings = {
+  themeMode: ThemeMode
+  soundEnabled: boolean
+  expandedUI: boolean
+  defaultModel: string
+}
+
+function loadSettings(): PersistedSettings {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY)
     if (raw) {
@@ -325,14 +336,24 @@ function loadSettings(): { themeMode: ThemeMode; soundEnabled: boolean; expanded
         themeMode: ['light', 'dark'].includes(parsed.themeMode) ? parsed.themeMode : 'dark',
         soundEnabled: typeof parsed.soundEnabled === 'boolean' ? parsed.soundEnabled : true,
         expandedUI: typeof parsed.expandedUI === 'boolean' ? parsed.expandedUI : false,
+        defaultModel: isKnownModelId(parsed.defaultModel) ? parsed.defaultModel : DEFAULT_MODEL_ID,
       }
     }
   } catch {}
-  return { themeMode: 'dark', soundEnabled: true, expandedUI: false }
+  return { themeMode: 'dark', soundEnabled: true, expandedUI: false, defaultModel: DEFAULT_MODEL_ID }
 }
 
-function saveSettings(s: { themeMode: ThemeMode; soundEnabled: boolean; expandedUI: boolean }): void {
+function saveSettings(s: PersistedSettings): void {
   try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(s)) } catch {}
+}
+
+function snapshotSettings(get: () => ThemeState): PersistedSettings {
+  return {
+    themeMode: get().themeMode,
+    soundEnabled: get().soundEnabled,
+    expandedUI: get().expandedUI,
+    defaultModel: get().defaultModel,
+  }
 }
 
 const saved = loadSettings()
@@ -342,6 +363,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   themeMode: saved.themeMode,
   soundEnabled: saved.soundEnabled,
   expandedUI: saved.expandedUI,
+  defaultModel: saved.defaultModel,
   _systemIsDark: true,
   setIsDark: (isDark) => {
     set({ isDark })
@@ -351,15 +373,20 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
     const resolved = mode === 'system' ? get()._systemIsDark : mode === 'dark'
     set({ themeMode: mode, isDark: resolved })
     applyTheme(resolved)
-    saveSettings({ themeMode: mode, soundEnabled: get().soundEnabled, expandedUI: get().expandedUI })
+    saveSettings(snapshotSettings(get))
   },
   setSoundEnabled: (enabled) => {
     set({ soundEnabled: enabled })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: enabled, expandedUI: get().expandedUI })
+    saveSettings(snapshotSettings(get))
   },
   setExpandedUI: (expanded) => {
     set({ expandedUI: expanded })
-    saveSettings({ themeMode: get().themeMode, soundEnabled: get().soundEnabled, expandedUI: expanded })
+    saveSettings(snapshotSettings(get))
+  },
+  setDefaultModel: (modelId) => {
+    const resolved = isKnownModelId(modelId) ? modelId : DEFAULT_MODEL_ID
+    set({ defaultModel: resolved })
+    saveSettings(snapshotSettings(get))
   },
   setSystemTheme: (isDark) => {
     set({ _systemIsDark: isDark })

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -4,6 +4,18 @@
  */
 import { create } from 'zustand'
 import { DEFAULT_MODEL_ID, isKnownModelId } from './models'
+import type { CliTerminalApp } from '../shared/types'
+
+export type { CliTerminalApp }
+
+export const CLI_TERMINAL_OPTIONS: { id: CliTerminalApp; label: string }[] = [
+  { id: 'terminal', label: 'Terminal' },
+  { id: 'iterm', label: 'iTerm' },
+]
+
+function isCliTerminalApp(value: unknown): value is CliTerminalApp {
+  return value === 'terminal' || value === 'iterm'
+}
 
 // ─── Color palettes ───
 
@@ -288,6 +300,8 @@ interface ThemeState {
   expandedUI: boolean
   /** Global default model for new sessions (per-session overrides live on TabState) */
   defaultModel: string
+  /** macOS app for "Open in CLI" */
+  cliTerminal: CliTerminalApp
   /** OS-reported dark mode — used when themeMode is 'system' */
   _systemIsDark: boolean
   setIsDark: (isDark: boolean) => void
@@ -295,6 +309,7 @@ interface ThemeState {
   setSoundEnabled: (enabled: boolean) => void
   setExpandedUI: (expanded: boolean) => void
   setDefaultModel: (modelId: string) => void
+  setCliTerminal: (app: CliTerminalApp) => void
   /** Called by OS theme change listener — updates system value */
   setSystemTheme: (isDark: boolean) => void
 }
@@ -325,6 +340,7 @@ type PersistedSettings = {
   soundEnabled: boolean
   expandedUI: boolean
   defaultModel: string
+  cliTerminal: CliTerminalApp
 }
 
 function loadSettings(): PersistedSettings {
@@ -337,10 +353,11 @@ function loadSettings(): PersistedSettings {
         soundEnabled: typeof parsed.soundEnabled === 'boolean' ? parsed.soundEnabled : true,
         expandedUI: typeof parsed.expandedUI === 'boolean' ? parsed.expandedUI : false,
         defaultModel: isKnownModelId(parsed.defaultModel) ? parsed.defaultModel : DEFAULT_MODEL_ID,
+        cliTerminal: isCliTerminalApp(parsed.cliTerminal) ? parsed.cliTerminal : 'terminal',
       }
     }
   } catch {}
-  return { themeMode: 'dark', soundEnabled: true, expandedUI: false, defaultModel: DEFAULT_MODEL_ID }
+  return { themeMode: 'dark', soundEnabled: true, expandedUI: false, defaultModel: DEFAULT_MODEL_ID, cliTerminal: 'terminal' }
 }
 
 function saveSettings(s: PersistedSettings): void {
@@ -353,6 +370,7 @@ function snapshotSettings(get: () => ThemeState): PersistedSettings {
     soundEnabled: get().soundEnabled,
     expandedUI: get().expandedUI,
     defaultModel: get().defaultModel,
+    cliTerminal: get().cliTerminal,
   }
 }
 
@@ -364,6 +382,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   soundEnabled: saved.soundEnabled,
   expandedUI: saved.expandedUI,
   defaultModel: saved.defaultModel,
+  cliTerminal: saved.cliTerminal,
   _systemIsDark: true,
   setIsDark: (isDark) => {
     set({ isDark })
@@ -386,6 +405,11 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   setDefaultModel: (modelId) => {
     const resolved = isKnownModelId(modelId) ? modelId : DEFAULT_MODEL_ID
     set({ defaultModel: resolved })
+    saveSettings(snapshotSettings(get))
+  },
+  setCliTerminal: (app) => {
+    if (!isCliTerminalApp(app)) return
+    set({ cliTerminal: app })
     saveSettings(snapshotSettings(get))
   },
   setSystemTheme: (isDark) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -158,6 +158,8 @@ export interface TabState {
   lastResult: RunResult | null
   /** Session metadata from init event */
   sessionModel: string | null
+  /** Per-session model override (persisted under ~/.claude/projects/ when sessionId is known) */
+  modelOverride: string | null
   sessionTools: string[]
   sessionMcpServers: Array<{ name: string; status: string }>
   sessionSkills: string[]
@@ -321,6 +323,8 @@ export const IPC = {
   ANIMATE_HEIGHT: 'clui:animate-height',
   LIST_SESSIONS: 'clui:list-sessions',
   LOAD_SESSION: 'clui:load-session',
+  GET_SESSION_MODEL: 'clui:get-session-model',
+  SET_SESSION_MODEL: 'clui:set-session-model',
 
   // One-way events (main → renderer)
   TEXT_CHUNK: 'clui:text-chunk',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -296,6 +296,9 @@ export interface CatalogPlugin {
   isSkillMd: boolean      // true = individual SKILL.md (direct install), false = CLI plugin (bundle install)
 }
 
+/** macOS terminal app used by "Open in CLI" */
+export type CliTerminalApp = 'terminal' | 'iterm'
+
 // ─── IPC Channel Names ───
 
 export const IPC = {


### PR DESCRIPTION
## Summary

- **Chat text selection** — Conversation area is selectable; window drag no longer steals clicks from message text. Tab strip remains the drag handle (with a small movement threshold so tab clicks still work).
- **Persisted preferences** — Full width and zoom level survive app restart; global default model is configurable in settings.
- **Model selection** — Settings set the global default; the status bar picker overrides the model for the current session only, stored in `~/.claude/projects/<project>/clui-models.json`.
- **Open in CLI** — Settings let users choose **Terminal** or **iTerm** for “Open in CLI” (macOS AppleScript).

## Details

| Area | Change |
|------|--------|
| Window drag | Manual drag respects `.no-drag` / `.conversation-selectable`; tab bar draggable |
| CSS | `cursor: text` on chat content |
| Settings | Full width, default model, CLI app (Terminal / iTerm) saved in `localStorage` (`clui-settings`) |
| Sessions | Per-session model map via new IPC + `clui-models.json` next to Claude JSONL files |
| Zoom | Already persisted in `~/Library/Application Support/clui/clui-zoom.json` (unchanged behavior, included in branch) |

## Test plan

- [ ] Select and copy text in an expanded chat (no window drag)
- [ ] Drag window from tab bar; click tabs without accidental drag
- [ ] Toggle **Full width**, restart app — setting retained
- [ ] Set **Default model** in ⋯ settings; new tab uses it
- [ ] Change model from status bar; resume session from history — session model restored
- [ ] Set **Open in CLI** to iTerm; click **Open in CLI** — iTerm opens with `cd` + `claude --resume` when applicable
- [ ] `npm run build` / `npm run dev` — no compile errors