### PR TITLE
fix: text selection in conversation blocked by window-drag handler

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -111,8 +111,11 @@ export default function App() {
 
     const onMouseDown = (e: MouseEvent) => {
       const el = e.target as HTMLElement
-      // Skip interactive elements — everything else on the card is draggable
-      if (el.closest('button, input, textarea, a, select, [role="button"], [contenteditable], .cm-editor')) return
+      // Skip interactive elements and selectable conversation text —
+      // everything else on the card is draggable. Without the
+      // .conversation-selectable exclusion, preventDefault() below kills
+      // text selection in the chat even though CSS allows it.
+      if (el.closest('button, input, textarea, a, select, [role="button"], [contenteditable], .cm-editor, .conversation-selectable')) return
       if (!el.closest('[data-clui-ui]')) return
       e.preventDefault()
       // Double-click: snap back to default position


### PR DESCRIPTION
## Problem

Text in the conversation view cannot be selected (and therefore not copied) by dragging the mouse, even though the CSS explicitly allows it (`.conversation-selectable` sets `user-select: text` in `index.css`).

Cause: the manual window-drag handler in `App.tsx` captures every `mousedown` on the card and calls `e.preventDefault()`. Interactive elements (buttons, inputs, links, …) are excluded, but conversation text is not — so dragging across a message moves the window instead of selecting text.

## Fix

Add `.conversation-selectable` to the drag handler's exclusion selector. Dragging still works everywhere else on the card (header, input bar edges, empty areas); selecting text in the chat works as the CSS always intended.

One line changed (plus comment).

## Testing

- Built and ran locally on macOS (Apple Silicon)
- Text in assistant/user messages is now selectable and copyable via mouse drag + ⌘C
- Window drag from header/empty areas still works, double-click snap-back unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)